### PR TITLE
Refresh Gantt chart UI to mirror reference design

### DIFF
--- a/plugins/redmine_canvas_gantt/spa/src/App.css
+++ b/plugins/redmine_canvas_gantt/spa/src/App.css
@@ -1,46 +1,39 @@
-#root {
-  width: 100%;
-  height: 100%;
-  margin: 0;
-  padding: 0;
-  text-align: left;
+.app-shell {
+  width: 100vw;
+  height: 100vh;
+  padding: 20px 24px;
+  box-sizing: border-box;
+  background: radial-gradient(circle at 20% 20%, #f8fbff 0, #f0f3f9 32%, #e7ebf5 55%, #e7ebf5 100%);
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
+.gantt-card {
+  flex: 1;
+  max-width: 1400px;
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+  border-radius: 18px;
+  box-shadow: 0 18px 38px rgba(0, 39, 99, 0.08);
+  border: 1px solid #e7ebf3;
+  overflow: hidden;
 }
 
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
+.gantt-body {
+  flex: 1;
+  display: flex;
+  background: #f9fafc;
+  border-top: 1px solid #eef1f6;
 }
 
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+@media (max-width: 1200px) {
+  .app-shell {
+    padding: 12px;
   }
 
-  to {
-    transform: rotate(360deg);
+  .gantt-card {
+    max-width: 100%;
   }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/plugins/redmine_canvas_gantt/spa/src/App.tsx
+++ b/plugins/redmine_canvas_gantt/spa/src/App.tsx
@@ -7,10 +7,12 @@ function App() {
   const [viewMode, setViewMode] = useState<'Day' | 'Week' | 'Month' | 'Quarter'>('Week');
 
   return (
-    <div className="app-container" style={{ display: 'flex', flexDirection: 'column', height: '100vh', width: '100vw' }}>
-      <GanttToolbar viewMode={viewMode} onViewModeChange={setViewMode} />
-      <div style={{ flex: 1, overflow: 'hidden', position: 'relative' }}>
-        <GanttContainer />
+    <div className="app-shell">
+      <div className="gantt-card">
+        <GanttToolbar viewMode={viewMode} onViewModeChange={setViewMode} />
+        <div className="gantt-body">
+          <GanttContainer />
+        </div>
       </div>
     </div>
   );

--- a/plugins/redmine_canvas_gantt/spa/src/components/GanttContainer.tsx
+++ b/plugins/redmine_canvas_gantt/spa/src/components/GanttContainer.tsx
@@ -83,10 +83,10 @@ export const GanttContainer: React.FC = () => {
     }, [viewport, tasks]);
 
     return (
-        <div ref={containerRef} style={{ display: 'flex', width: '100%', height: '100%', overflow: 'hidden' }}>
+        <div ref={containerRef} style={{ display: 'flex', width: '100%', height: '100%', overflow: 'hidden', background: '#f9fafc' }}>
             <UiSidebar />
 
-            <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+            <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, background: '#ffffff' }}>
                 <TimelineHeader />
                 {/* Timeline Pane */}
                 <div ref={mainPaneRef} style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>

--- a/plugins/redmine_canvas_gantt/spa/src/components/GanttToolbar.tsx
+++ b/plugins/redmine_canvas_gantt/spa/src/components/GanttToolbar.tsx
@@ -6,33 +6,35 @@ interface GanttToolbarProps {
 }
 
 export const GanttToolbar: React.FC<GanttToolbarProps> = ({ viewMode, onViewModeChange }) => {
+    const baseButton: React.CSSProperties = {
+        border: '1px solid #e5e9f3',
+        backgroundColor: '#fff',
+        color: '#3b4256',
+        padding: '10px 14px',
+        borderRadius: '10px',
+        fontSize: '14px',
+        fontWeight: 600,
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px',
+        cursor: 'pointer',
+        boxShadow: '0 4px 10px rgba(16, 38, 87, 0.04)'
+    };
+
     return (
         <div style={{
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'space-between',
-            padding: '10px 20px',
+            padding: '16px 20px',
             backgroundColor: '#ffffff',
-            borderBottom: '1px solid #e0e0e0',
-            height: '60px',
+            height: '72px',
             boxSizing: 'border-box'
         }}>
             {/* Left: Filter */}
             <div style={{ display: 'flex', gap: '10px' }}>
                 <button
-                    style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '8px',
-                        padding: '8px 16px',
-                        borderRadius: '6px',
-                        border: '1px solid #e0e0e0',
-                        backgroundColor: '#fff',
-                        color: '#333',
-                        fontSize: '14px',
-                        fontWeight: 500,
-                        cursor: 'pointer'
-                    }}
+                    style={{ ...baseButton, padding: '10px 16px' }}
                 >
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                         <line x1="4" y1="6" x2="20" y2="6" />
@@ -44,13 +46,14 @@ export const GanttToolbar: React.FC<GanttToolbarProps> = ({ viewMode, onViewMode
             </div>
 
             {/* Right: View Mode & Add Task */}
-            <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
                 <div style={{
                     display: 'flex',
-                    backgroundColor: '#f1f3f5',
-                    borderRadius: '8px',
+                    backgroundColor: '#f3f6fb',
+                    borderRadius: '12px',
                     padding: '4px',
-                    gap: '4px'
+                    gap: '4px',
+                    border: '1px solid #e5e9f3'
                 }}>
                     {(['Day', 'Week', 'Month', 'Quarter'] as const).map((mode) => (
                         <button
@@ -58,14 +61,14 @@ export const GanttToolbar: React.FC<GanttToolbarProps> = ({ viewMode, onViewMode
                             onClick={() => onViewModeChange(mode)}
                             style={{
                                 border: 'none',
-                                background: viewMode === mode ? '#fff' : 'transparent',
-                                color: viewMode === mode ? '#333' : '#666',
-                                padding: '6px 12px',
-                                borderRadius: '6px',
+                                background: viewMode === mode ? '#e5f0ff' : 'transparent',
+                                color: viewMode === mode ? '#2f5fd6' : '#5a6272',
+                                padding: '8px 14px',
+                                borderRadius: '10px',
                                 fontSize: '13px',
-                                fontWeight: 500,
+                                fontWeight: 700,
                                 cursor: 'pointer',
-                                boxShadow: viewMode === mode ? '0 1px 3px rgba(0,0,0,0.1)' : 'none',
+                                boxShadow: viewMode === mode ? '0 6px 14px rgba(47, 95, 214, 0.12)' : 'none',
                                 transition: 'all 0.2s'
                             }}
                         >
@@ -76,14 +79,24 @@ export const GanttToolbar: React.FC<GanttToolbarProps> = ({ viewMode, onViewMode
 
                 <button
                     style={{
-                        backgroundColor: '#0066cc',
-                        color: 'white',
+                        ...baseButton,
+                        borderColor: '#ffe6e6',
+                        backgroundColor: '#fff7f7',
+                        color: '#de5148'
+                    }}
+                >
+                    <span style={{ width: 12, height: 12, borderRadius: 12, background: '#de5148', display: 'inline-block' }} />
+                    Today
+                </button>
+
+                <button
+                    style={{
+                        ...baseButton,
+                        background: 'linear-gradient(90deg, #0062e0 0%, #3a8ef6 100%)',
+                        color: '#ffffff',
                         border: 'none',
-                        borderRadius: '6px',
-                        padding: '8px 16px',
-                        fontSize: '14px',
-                        fontWeight: 600,
-                        cursor: 'pointer'
+                        padding: '12px 18px',
+                        boxShadow: '0 10px 18px rgba(0, 107, 235, 0.25)'
                     }}
                 >
                     Add Task

--- a/plugins/redmine_canvas_gantt/spa/src/components/TimelineHeader.tsx
+++ b/plugins/redmine_canvas_gantt/spa/src/components/TimelineHeader.tsx
@@ -16,9 +16,9 @@ export const TimelineHeader: React.FC = () => {
             ctx.clearRect(0, 0, canvas.width, canvas.height);
 
             // Header Background
-            ctx.fillStyle = '#f8f9fa';
+            ctx.fillStyle = '#ffffff';
             ctx.fillRect(0, 0, canvas.width, canvas.height);
-            ctx.strokeStyle = '#e0e0e0';
+            ctx.strokeStyle = '#e6e9f1';
             ctx.beginPath();
             ctx.moveTo(0, canvas.height - 0.5);
             ctx.lineTo(canvas.width, canvas.height - 0.5);
@@ -33,8 +33,8 @@ export const TimelineHeader: React.FC = () => {
 
             let currentTime = Math.floor(visibleStartTime / ONE_DAY) * ONE_DAY;
 
-            ctx.fillStyle = '#666';
-            ctx.font = '500 12px sans-serif';
+            ctx.fillStyle = '#4a5365';
+            ctx.font = '600 12px "Inter", sans-serif';
             ctx.textAlign = 'center';
 
             while (currentTime <= visibleEndTime) {
@@ -52,9 +52,9 @@ export const TimelineHeader: React.FC = () => {
                 if (x + dayWidth >= 0 && x <= canvas.width) {
                     // Draw tick
                     ctx.beginPath();
-                    ctx.moveTo(Math.floor(x) + 0.5, canvas.height - 10);
+                    ctx.moveTo(Math.floor(x) + 0.5, canvas.height - 12);
                     ctx.lineTo(Math.floor(x) + 0.5, canvas.height);
-                    ctx.strokeStyle = '#ccc';
+                    ctx.strokeStyle = '#d9dde6';
                     ctx.stroke();
 
                     // Draw Text (e.g., "12 Mon")
@@ -65,9 +65,9 @@ export const TimelineHeader: React.FC = () => {
                     // If zoomed out, maybe only show day number or less texts. 
                     // For now assume standard zoom.
 
-                    if (dayWidth > 30) {
+                    if (dayWidth > 28) {
                         const centerX = x + dayWidth / 2;
-                        ctx.fillText(dayStr, centerX, canvas.height - 14);
+                        ctx.fillText(dayStr, centerX, canvas.height - 18);
                     }
                 }
                 currentTime += ONE_DAY;
@@ -79,18 +79,18 @@ export const TimelineHeader: React.FC = () => {
 
             if (todayX >= 0 && todayX <= canvas.width) {
                 // Tag style
-                ctx.fillStyle = '#ff5252';
-                const tagWidth = 50;
-                const tagHeight = 20;
+                ctx.fillStyle = '#de5148';
+                const tagWidth = 58;
+                const tagHeight = 22;
                 const tagX = todayX - tagWidth / 2;
-                const tagY = 10; // Vertically centered roughly
+                const tagY = 12; // Vertically centered roughly
 
                 ctx.beginPath();
                 ctx.roundRect(tagX, tagY, tagWidth, tagHeight, 4);
                 ctx.fill();
 
                 ctx.fillStyle = 'white';
-                ctx.font = 'bold 11px sans-serif';
+                ctx.font = '700 11px "Inter", sans-serif';
                 ctx.textAlign = 'center';
                 ctx.fillText('Today', todayX, tagY + 14);
             }
@@ -108,7 +108,7 @@ export const TimelineHeader: React.FC = () => {
             const entry = entries[0];
             if (canvasRef.current) {
                 canvasRef.current.width = entry.contentRect.width;
-                canvasRef.current.height = 48; // Fixed height
+                canvasRef.current.height = 56; // Fixed height
                 // Trigger re-render by updating state? or just call helper?
                 // The viewport dependency above will handle redraw if viewport update triggers it.
                 // But changing width might not trigger viewport update immediately if not synced.
@@ -120,8 +120,8 @@ export const TimelineHeader: React.FC = () => {
     }, []);
 
     return (
-        <div style={{ height: 48, backgroundColor: '#f8f9fa', borderBottom: '1px solid #e0e0e0', overflow: 'hidden' }}>
-            <canvas ref={canvasRef} height={48} style={{ display: 'block' }} />
+        <div style={{ height: 56, backgroundColor: '#ffffff', borderBottom: '1px solid #e6e9f1', overflow: 'hidden' }}>
+            <canvas ref={canvasRef} height={56} style={{ display: 'block' }} />
         </div>
     );
 };

--- a/plugins/redmine_canvas_gantt/spa/src/components/UiSidebar.tsx
+++ b/plugins/redmine_canvas_gantt/spa/src/components/UiSidebar.tsx
@@ -9,24 +9,18 @@ const getInitials = (name?: string) => {
     return name.split(' ').map(n => n[0]).join('').substring(0, 2).toUpperCase();
 };
 
-const ProgressCircle = ({ ratio }: { ratio: number }) => {
-    const r = 8;
-    const c = 2 * Math.PI * r;
-    const offset = c - (ratio / 100) * c;
-
-    // Choose color based on progress (green if done or high, blue otherwise)
-    const color = ratio === 100 ? '#4caf50' : '#2196f3';
-
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-            <svg width="20" height="20" viewBox="0 0 20 20" style={{ transform: 'rotate(-90deg)' }}>
-                <circle cx="10" cy="10" r={r} fill="none" stroke="#e0e0e0" strokeWidth="3" />
-                <circle cx="10" cy="10" r={r} fill="none" stroke={color} strokeWidth="3" strokeDasharray={c} strokeDashoffset={offset} strokeLinecap="round" />
-            </svg>
-            <span style={{ fontSize: '12px', color: '#666' }}>{ratio}%</span>
-        </div>
-    );
+const formatDate = (value: number) => {
+    return new Date(value).toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: '2-digit' });
 };
+
+const ProgressBar = ({ ratio, tone }: { ratio: number; tone: string }) => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '10px', width: '100%' }}>
+        <div style={{ flex: 1, height: 8, background: '#eef2f7', borderRadius: 999, overflow: 'hidden', boxShadow: 'inset 0 1px 2px rgba(16,38,87,0.08)' }}>
+            <div style={{ width: `${Math.min(100, ratio)}%`, height: '100%', background: tone, borderRadius: 999 }} />
+        </div>
+        <span style={{ fontSize: 12, fontWeight: 700, color: '#3d4354', minWidth: 36, textAlign: 'right' }}>{ratio}%</span>
+    </div>
+);
 
 export const UiSidebar: React.FC = () => {
     const tasks = useTaskStore(state => state.tasks);
@@ -48,30 +42,36 @@ export const UiSidebar: React.FC = () => {
         {
             key: 'subject',
             title: 'Task Name',
-            width: 280,
-            render: (t: Task) => (
-                <div style={{ display: 'flex', alignItems: 'center', paddingLeft: t.parentId ? '24px' : '4px', fontWeight: t.parentId ? 400 : 500 }}>
-                    {/* Creating a chevron icon using CSS/SVG could go here for parent tasks */}
-                    <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{t.subject}</span>
-                </div>
-            )
+            width: 300,
+            render: (t: Task) => {
+                const style = getStatusColor(t.statusId);
+                return (
+                    <div style={{ display: 'flex', alignItems: 'center', paddingLeft: t.parentId ? 28 : 12, gap: 10, fontWeight: t.parentId ? 600 : 700, color: '#2c3544', letterSpacing: '-0.01em' }}>
+                        <span style={{ width: 10, height: 10, borderRadius: '50%', background: style.bar, boxShadow: '0 0 0 4px rgba(61,127,245,0.08)' }} />
+                        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{t.subject}</span>
+                    </div>
+                );
+            }
         },
         {
             key: 'status',
             title: 'Status',
-            width: 100,
+            width: 120,
             render: (t: Task) => {
                 const style = getStatusColor(t.statusId);
                 return (
                     <span style={{
                         backgroundColor: style.bg,
                         color: style.text,
-                        padding: '2px 8px',
+                        padding: '6px 10px',
                         borderRadius: '12px',
                         fontSize: '11px',
-                        fontWeight: 600,
-                        display: 'inline-block',
-                        whiteSpace: 'nowrap'
+                        fontWeight: 700,
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        whiteSpace: 'nowrap',
+                        boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.8)'
                     }}>
                         {style.label}
                     </span>
@@ -81,37 +81,40 @@ export const UiSidebar: React.FC = () => {
         {
             key: 'assignee',
             title: 'Assignee',
-            width: 80,
+            width: 110,
             render: (t: Task) => (
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                     {t.assignedToName && (
                         <div style={{
-                            width: '24px',
-                            height: '24px',
+                            width: '28px',
+                            height: '28px',
                             borderRadius: '50%',
-                            backgroundColor: '#bdbdbd',
+                            background: 'linear-gradient(135deg, #5a6ff0 0%, #7ac5ff 100%)',
                             display: 'flex',
                             alignItems: 'center',
                             color: 'white',
                             justifyContent: 'center',
-                            fontSize: '10px'
+                            fontSize: '11px',
+                            boxShadow: '0 6px 12px rgba(90,111,240,0.18)'
                         }}
                             title={t.assignedToName}
                         >
-                            {/* In real app, check for avatar URL */}
                             {getInitials(t.assignedToName)}
                         </div>
                     )}
                 </div>
             )
         },
-        { key: 'startDate', title: 'Start Date', width: 90, render: (t: Task) => <span style={{ color: '#666' }}>{new Date(t.startDate).toLocaleDateString()}</span> },
-        { key: 'dueDate', title: 'Due Date', width: 90, render: (t: Task) => <span style={{ color: '#666' }}>{new Date(t.dueDate).toLocaleDateString()}</span> },
+        { key: 'startDate', title: 'Start Date', width: 110, render: (t: Task) => <span style={{ color: '#6a7282', fontWeight: 600 }}>{formatDate(t.startDate)}</span> },
+        { key: 'dueDate', title: 'Due Date', width: 110, render: (t: Task) => <span style={{ color: '#6a7282', fontWeight: 600 }}>{formatDate(t.dueDate)}</span> },
         {
             key: 'ratioDone',
             title: 'Progress',
-            width: 80,
-            render: (t: Task) => <ProgressCircle ratio={t.ratioDone} />
+            width: 130,
+            render: (t: Task) => {
+                const style = getStatusColor(t.statusId);
+                return <ProgressBar ratio={t.ratioDone} tone={style.progress || style.bar} />;
+            }
         },
     ];
 
@@ -121,8 +124,8 @@ export const UiSidebar: React.FC = () => {
         <div
             style={{
                 width: totalWidth,
-                backgroundColor: '#ffffff',
-                borderRight: '1px solid #e0e0e0',
+                backgroundColor: '#fdfefe',
+                borderRight: '1px solid #e6e9f1',
                 display: 'flex',
                 flexDirection: 'column',
                 height: '100%',
@@ -132,22 +135,24 @@ export const UiSidebar: React.FC = () => {
         >
             {/* Header */}
             <div style={{
-                height: 48, // Taller header
-                borderBottom: '1px solid #e0e0e0',
+                height: 54,
+                borderBottom: '1px solid #e6e9f1',
                 display: 'flex',
-                fontWeight: 600,
-                backgroundColor: '#f8f9fa',
+                fontWeight: 700,
+                background: 'linear-gradient(180deg, #f8fafc 0%, #f2f5fa 100%)',
                 color: '#444',
-                fontSize: '13px'
+                fontSize: '13px',
+                letterSpacing: '0.02em'
             }}>
                 {columns.map((col, idx) => (
                     <div key={idx} style={{
                         width: col.width,
-                        padding: '0 8px',
-                        borderRight: '1px solid #f0f0f0',
+                        padding: '0 12px',
+                        borderRight: idx === columns.length - 1 ? 'none' : '1px solid #f1f3f7',
                         display: 'flex',
                         alignItems: 'center',
-                        overflow: 'hidden'
+                        overflow: 'hidden',
+                        boxSizing: 'border-box'
                     }}>
                         {col.title}
                     </div>
@@ -155,7 +160,7 @@ export const UiSidebar: React.FC = () => {
             </div>
 
             {/* Body */}
-            <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
+            <div style={{ flex: 1, position: 'relative', overflow: 'hidden', background: '#ffffff' }}>
                 {visibleTasks.map(task => {
                     const top = task.rowIndex * viewport.rowHeight - viewport.scrollY;
                     const isSelected = task.id === selectedTaskId;
@@ -171,23 +176,25 @@ export const UiSidebar: React.FC = () => {
                                 height: viewport.rowHeight,
                                 width: totalWidth,
                                 display: 'flex',
-                                borderBottom: '1px solid #f5f5f5',
-                                backgroundColor: isSelected ? '#f0f7ff' : 'white',
+                                borderBottom: '1px solid #f0f3f8',
+                                backgroundColor: isSelected ? '#f0f5ff' : 'white',
                                 cursor: 'pointer',
                                 fontSize: '13px',
                                 color: '#333',
-                                transition: 'background-color 0.1s'
+                                transition: 'background-color 0.1s',
+                                boxSizing: 'border-box'
                             }}
                         >
                             {columns.map((col, idx) => (
                                 <div key={idx} style={{
                                     width: col.width,
-                                    padding: '0 8px',
-                                    borderRight: '1px solid #f9f9f9',
+                                    padding: '0 12px',
+                                    borderRight: idx === columns.length - 1 ? 'none' : '1px solid #f8f9fb',
                                     display: 'flex',
                                     alignItems: 'center',
                                     overflow: 'hidden',
-                                    whiteSpace: 'nowrap'
+                                    whiteSpace: 'nowrap',
+                                    boxSizing: 'border-box'
                                 }}>
                                     {col.render ? col.render(task) : (task as any)[col.key]}
                                 </div>

--- a/plugins/redmine_canvas_gantt/spa/src/engines/LayoutEngine.ts
+++ b/plugins/redmine_canvas_gantt/spa/src/engines/LayoutEngine.ts
@@ -24,9 +24,10 @@ export class LayoutEngine {
         const y = task.rowIndex * viewport.rowHeight - viewport.scrollY;
         // Ensure width is at least something visible (e.g., 2px) even if duration is 0
         const width = Math.max(2, (task.dueDate - task.startDate) * viewport.scale);
-        const height = viewport.rowHeight - 10; // Padding
+        const innerHeight = Math.min(viewport.rowHeight - 14, 26);
+        const offsetY = (viewport.rowHeight - innerHeight) / 2;
 
-        return { x, y: y + 5, width, height }; // Centered in row
+        return { x, y: y + offsetY, width, height: innerHeight }; // Centered in row
     }
 
     /**

--- a/plugins/redmine_canvas_gantt/spa/src/index.css
+++ b/plugins/redmine_canvas_gantt/spa/src/index.css
@@ -4,8 +4,8 @@
   font-weight: 400;
 
   color-scheme: light;
-  color: #333;
-  background-color: #f4f5f7;
+  color: #1f2937;
+  background-color: #e9edf5;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;

--- a/plugins/redmine_canvas_gantt/spa/src/renderers/BackgroundRenderer.ts
+++ b/plugins/redmine_canvas_gantt/spa/src/renderers/BackgroundRenderer.ts
@@ -13,11 +13,11 @@ export class BackgroundRenderer {
 
         // Clear
         ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-        ctx.fillStyle = '#f5f5f5';
+        ctx.fillStyle = '#ffffff';
         ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
 
         // Grid (Day lines)
-        ctx.strokeStyle = '#e0e0e0';
+        ctx.strokeStyle = '#e5e8ef';
         ctx.lineWidth = 1;
         ctx.beginPath();
 
@@ -32,7 +32,7 @@ export class BackgroundRenderer {
             const x = (currentTime - viewport.startDate) * viewport.scale - viewport.scrollX;
             if (x >= 0 && x <= this.canvas.width) {
                 // Dashed line for grid
-                ctx.setLineDash([4, 4]);
+                ctx.setLineDash([2, 8]);
                 ctx.moveTo(Math.floor(x) + 0.5, 0);
                 ctx.lineTo(Math.floor(x) + 0.5, this.canvas.height);
             }
@@ -40,6 +40,20 @@ export class BackgroundRenderer {
         }
         ctx.stroke();
         ctx.setLineDash([]); // Reset dash
+
+        // Horizontal separators per row
+        const { rowHeight, scrollY, height } = viewport;
+        const startRow = Math.floor(scrollY / rowHeight);
+        const endRow = Math.ceil((scrollY + height) / rowHeight);
+
+        ctx.strokeStyle = '#f0f2f7';
+        ctx.beginPath();
+        for (let row = startRow; row <= endRow; row++) {
+            const y = row * rowHeight - scrollY;
+            ctx.moveTo(0, Math.floor(y) + 0.5);
+            ctx.lineTo(this.canvas.width, Math.floor(y) + 0.5);
+        }
+        ctx.stroke();
 
         // Draw "Today" line
         const now = Date.now();

--- a/plugins/redmine_canvas_gantt/spa/src/renderers/OverlayRenderer.ts
+++ b/plugins/redmine_canvas_gantt/spa/src/renderers/OverlayRenderer.ts
@@ -38,7 +38,7 @@ export class OverlayRenderer {
         tasks: Task[],
         relations: Relation[]
     ) {
-        ctx.strokeStyle = '#888';
+        ctx.strokeStyle = '#c1c9d6';
         ctx.lineWidth = 1.5;
 
         for (const rel of relations) {
@@ -82,7 +82,7 @@ export class OverlayRenderer {
             ctx.lineTo(x + size, y + size / 2);
         }
         ctx.closePath();
-        ctx.fillStyle = '#888';
+        ctx.fillStyle = '#c1c9d6';
         ctx.fill();
     }
 

--- a/plugins/redmine_canvas_gantt/spa/src/renderers/TaskRenderer.ts
+++ b/plugins/redmine_canvas_gantt/spa/src/renderers/TaskRenderer.ts
@@ -25,22 +25,47 @@ export class TaskRenderer {
             const style = getStatusColor(task.statusId);
 
             // Draw Bar Background (lighter or main color)
-            this.drawRoundedRect(ctx, bounds.x, bounds.y, bounds.width, bounds.height, 6, style.bar);
+            ctx.save();
+            ctx.shadowColor = style.shadow || 'rgba(0,0,0,0.08)';
+            ctx.shadowBlur = 12;
+            ctx.shadowOffsetY = 6;
+            this.drawRoundedRect(ctx, bounds.x, bounds.y, bounds.width, bounds.height, 8, style.bar);
+            ctx.shadowColor = 'transparent';
+            ctx.shadowBlur = 0;
+
+            // Stroke outline for crispness
+            ctx.strokeStyle = 'rgba(255,255,255,0.6)';
+            ctx.lineWidth = 1;
+            ctx.stroke();
+
+            ctx.restore();
 
             // Draw Progress
             if (task.ratioDone > 0) {
                 const progressWidth = (bounds.width * task.ratioDone) / 100;
                 // Clip progress to rounded rect
                 ctx.save();
-                this.clipRoundedRect(ctx, bounds.x, bounds.y, bounds.width, bounds.height, 6);
+                this.clipRoundedRect(ctx, bounds.x, bounds.y, bounds.width, bounds.height, 8);
 
-                ctx.fillStyle = 'rgba(0, 0, 0, 0.2)'; // Darken overlay
+                ctx.fillStyle = style.progress || 'rgba(255,255,255,0.35)';
+                ctx.globalAlpha = 0.3;
                 ctx.fillRect(bounds.x, bounds.y, progressWidth, bounds.height);
+                ctx.globalAlpha = 1;
+                ctx.restore();
+            }
+
+            // Label inside bar
+            if (bounds.width > 80) {
+                ctx.save();
+                ctx.fillStyle = '#ffffff';
+                ctx.font = '600 12px "Inter", sans-serif';
+                ctx.textBaseline = 'middle';
+                ctx.fillText(style.label, bounds.x + 12, bounds.y + bounds.height / 2);
                 ctx.restore();
             }
 
             // Draw Label (optional, maybe to the right side if it fits or outside)
-            // For now, let's keep it simple or remove if Sidebar has it. 
+            // For now, let's keep it simple or remove if Sidebar has it.
             // The image shows labels primarily in the sidebar, or maybe distinct bar types.
             // Let's not draw text on bar for now to match the clean look in the image (Sidebar has names).
         });

--- a/plugins/redmine_canvas_gantt/spa/src/stores/TaskStore.ts
+++ b/plugins/redmine_canvas_gantt/spa/src/stores/TaskStore.ts
@@ -26,7 +26,7 @@ const DEFAULT_VIEWPORT: Viewport = {
     scale: 0.0000005787, // ~50px per day
     width: 800,
     height: 600,
-    rowHeight: 40
+    rowHeight: 44
 };
 
 export const useTaskStore = create<TaskState>((set) => ({

--- a/plugins/redmine_canvas_gantt/spa/src/utils/styles.ts
+++ b/plugins/redmine_canvas_gantt/spa/src/utils/styles.ts
@@ -3,12 +3,15 @@
 export const getStatusColor = (statusId: number) => {
     // 1: New, 2: In Progress, 3: Resolved, 4: Feedback, 5: Closed, 6: Rejected
     switch (statusId) {
-        case 2: return { bg: '#e3f2fd', text: '#1976d2', bar: '#42a5f5', label: 'In Progress' };
+        case 2:
+            return { bg: '#e6efff', text: '#2f5fd6', bar: '#3d7ff5', label: 'In Progress', progress: '#6ba4ff', shadow: 'rgba(61, 127, 245, 0.28)' };
         case 3: // Resolved (Treat as Done-ish)
-        case 5: return { bg: '#e8f5e9', text: '#2e7d32', bar: '#66bb6a', label: 'Done' };
+        case 5:
+            return { bg: '#e8f6ee', text: '#0f7d48', bar: '#40c57c', label: 'Completed', progress: '#63d695', shadow: 'rgba(16, 125, 72, 0.24)' };
         case 6: // Rejected (Blocked)
         case 4: // Feedback (Warning)
-            return { bg: '#fff3e0', text: '#ef6c00', bar: '#ffa726', label: 'Blocked' };
-        default: return { bg: '#f5f5f5', text: '#616161', bar: '#bdbdbd', label: 'New' };
+            return { bg: '#fff2e6', text: '#c45b12', bar: '#f2a03f', label: 'Blacklisted', progress: '#ffb36b', shadow: 'rgba(244, 160, 63, 0.25)' };
+        default:
+            return { bg: '#eef2f7', text: '#4c566a', bar: '#aebad0', label: 'Planned', progress: '#c7d1e3', shadow: 'rgba(174, 186, 208, 0.22)' };
     }
 };


### PR DESCRIPTION
## Summary
- restyle the toolbar and shell layout to mirror the provided Gantt design with segmented view controls and primary actions
- redesign the task sidebar with status pills, avatars, formatted dates, and progress indicators aligned to the reference
- update timeline rendering (row height, background grid, bar styling, and today marker) for the refreshed visual theme

## Testing
- not run (UI changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aea5cf4dc8324bd6baeb264e7ada6)