### PR TITLE
Add collapsible Gantt rows and single-click issue navigation

### DIFF
--- a/plugins/redmine_canvas_gantt/spa/src/types/index.ts
+++ b/plugins/redmine_canvas_gantt/spa/src/types/index.ts
@@ -17,6 +17,7 @@ export interface Task {
     // Computed for layout (cached)
     rowIndex: number;
     hasChildren: boolean;
+    indentLevel?: number;
 }
 
 export interface Relation {


### PR DESCRIPTION
## Summary
- maintain expansion state for projects and parent tasks and rebuild layout to hide descendants when collapsed
- render indentation and toggle controls in the sidebar so users can fold or unfold projects and task trees
- add single-click navigation from task bars and sidebar rows to the Redmine issue detail while ignoring drag gestures

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e4f110f0c8324bf1659035a4b2cc7)