### PR TITLE
ガントチャートを全画面表示できるようにする

### DIFF
--- a/plugins/redmine_canvas_gantt/spa/src/App.css
+++ b/plugins/redmine_canvas_gantt/spa/src/App.css
@@ -6,6 +6,14 @@
   text-align: left;
 }
 
+.app-container.is-fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  background-color: #f4f5f7;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+}
+
 .logo {
   height: 6em;
   padding: 1.5em;

--- a/plugins/redmine_canvas_gantt/spa/src/App.tsx
+++ b/plugins/redmine_canvas_gantt/spa/src/App.tsx
@@ -1,15 +1,44 @@
+import { useEffect, useRef } from 'react';
 import { useTaskStore } from './stores/TaskStore';
 import { GanttContainer } from './components/GanttContainer';
 import { GanttToolbar } from './components/GanttToolbar';
 import Toast from './components/Toast';
 import BatchEditDialog from './components/BatchEditDialog';
+import { useUIStore } from './stores/UIStore';
 import './App.css';
 
 function App() {
   const { zoomLevel, setZoomLevel, isBatchEditMode } = useTaskStore();
+  const { isFullScreen, setFullScreen } = useUIStore();
+  const previousOverflow = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    const bodyStyle = document.body.style;
+
+    if (isFullScreen) {
+      previousOverflow.current = bodyStyle.overflow;
+      bodyStyle.overflow = 'hidden';
+    } else if (previousOverflow.current !== undefined) {
+      bodyStyle.overflow = previousOverflow.current;
+    }
+  }, [isFullScreen]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setFullScreen(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [setFullScreen]);
 
   return (
-    <div className="app-container" style={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%' }}>
+    <div
+      className={`app-container ${isFullScreen ? 'is-fullscreen' : ''}`}
+      style={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%' }}
+    >
       <GanttToolbar zoomLevel={zoomLevel} onZoomChange={setZoomLevel} />
       <div style={{ flex: 1, overflow: 'hidden', position: 'relative' }}>
         <GanttContainer />

--- a/plugins/redmine_canvas_gantt/spa/src/components/GanttToolbar.tsx
+++ b/plugins/redmine_canvas_gantt/spa/src/components/GanttToolbar.tsx
@@ -11,7 +11,16 @@ interface GanttToolbarProps {
 
 export const GanttToolbar: React.FC<GanttToolbarProps> = ({ zoomLevel, onZoomChange }) => {
     const { viewport, updateViewport, groupByProject, setGroupByProject, filterText, setFilterText } = useTaskStore();
-    const { showProgressLine, toggleProgressLine, visibleColumns, setVisibleColumns, leftPaneVisible, toggleLeftPane } = useUIStore();
+    const {
+        showProgressLine,
+        toggleProgressLine,
+        visibleColumns,
+        setVisibleColumns,
+        leftPaneVisible,
+        toggleLeftPane,
+        isFullScreen,
+        toggleFullScreen
+    } = useUIStore();
     const [showColumnMenu, setShowColumnMenu] = React.useState(false);
     const [showFilterMenu, setShowFilterMenu] = React.useState(false);
 
@@ -339,6 +348,44 @@ export const GanttToolbar: React.FC<GanttToolbarProps> = ({ zoomLevel, onZoomCha
                     Today
                 </button>
 
+                <button
+                    onClick={toggleFullScreen}
+                    style={{
+                        padding: '6px 16px',
+                        borderRadius: '6px',
+                        border: '1px solid #e0e0e0',
+                        backgroundColor: isFullScreen ? '#1a73e8' : '#fff',
+                        color: isFullScreen ? '#fff' : '#333',
+                        fontSize: '13px',
+                        fontWeight: 600,
+                        cursor: 'pointer',
+                        height: '32px',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '6px'
+                    }}
+                    title={isFullScreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+                >
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                        {isFullScreen ? (
+                            <>
+                                <polyline points="9 9 3 9 3 3" />
+                                <line x1="3" y1="3" x2="9" y2="9" />
+                                <polyline points="15 15 21 15 21 21" />
+                                <line x1="15" y1="15" x2="21" y2="21" />
+                            </>
+                        ) : (
+                            <>
+                                <polyline points="3 9 9 9 9 3" />
+                                <line x1="9" y1="3" x2="3" y2="9" />
+                                <polyline points="21 15 15 15 15 21" />
+                                <line x1="15" y1="21" x2="21" y2="15" />
+                            </>
+                        )}
+                    </svg>
+                    {isFullScreen ? 'Exit Fullscreen' : 'Fullscreen'}
+                </button>
+
                 <div style={{
                     display: 'flex',
                     backgroundColor: '#e9ecef',
@@ -374,6 +421,6 @@ export const GanttToolbar: React.FC<GanttToolbarProps> = ({ zoomLevel, onZoomCha
                     })}
                 </div>
             </div>
-        </div >
+        </div>
     );
 };

--- a/plugins/redmine_canvas_gantt/spa/src/stores/UIStore.ts
+++ b/plugins/redmine_canvas_gantt/spa/src/stores/UIStore.ts
@@ -20,6 +20,7 @@ interface UIState {
     sidebarWidth: number;
     leftPaneVisible: boolean;
     activeInlineEdit: { taskId: string; field: string; source?: 'cell' | 'panel' } | null;
+    isFullScreen: boolean;
     addNotification: (message: string, type?: NotificationType) => void;
     removeNotification: (id: string) => void;
     toggleProgressLine: () => void;
@@ -28,6 +29,8 @@ interface UIState {
     setColumnWidth: (key: string, width: number) => void;
     setSidebarWidth: (width: number) => void;
     setActiveInlineEdit: (value: { taskId: string; field: string; source?: 'cell' | 'panel' } | null) => void;
+    setFullScreen: (value: boolean) => void;
+    toggleFullScreen: () => void;
 }
 
 export const useUIStore = create<UIState>((set) => ({
@@ -48,6 +51,7 @@ export const useUIStore = create<UIState>((set) => ({
     },
     sidebarWidth: preferences.sidebarWidth ?? 400,
     activeInlineEdit: null,
+    isFullScreen: false,
     addNotification: (message, type = 'info') => {
         const id = Math.random().toString(36).substring(7);
         set((state) => ({
@@ -70,5 +74,7 @@ export const useUIStore = create<UIState>((set) => ({
     setVisibleColumns: (cols) => set(() => ({ visibleColumns: cols })),
     setColumnWidth: (key, width) => set((state) => ({ columnWidths: { ...state.columnWidths, [key]: width } })),
     setSidebarWidth: (width) => set(() => ({ sidebarWidth: width })),
-    setActiveInlineEdit: (value) => set(() => ({ activeInlineEdit: value }))
+    setActiveInlineEdit: (value) => set(() => ({ activeInlineEdit: value })),
+    setFullScreen: (value) => set(() => ({ isFullScreen: value })),
+    toggleFullScreen: () => set((state) => ({ isFullScreen: !state.isFullScreen }))
 }));


### PR DESCRIPTION
## Summary
- ツールバーに全画面/解除を切り替えるボタンを追加し、ガントビューをウィンドウ全体に広げられるようにしました
- 全画面時はアプリコンテナを固定配置して背景を覆い、Escキーで解除できるようにしました
- 全画面状態をUIストアで管理し、背景スクロールを抑止する処理を追加しました

## Testing
- pnpm run lint *(node_modulesが存在せず、@eslint/jsが見つからないため失敗)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69402ed26a9c83248454eee06e9f1537)