### PR TITLE
Prefer issue_from_id when normalizing relations and add test

### DIFF
--- a/spa/src/api/client.test.ts
+++ b/spa/src/api/client.test.ts
@@ -117,6 +117,34 @@ describe('apiClient.createRelation', () => {
         }));
         expect(rel).toEqual({ id: '2', from: '10', to: '11', type: 'precedes', delay: 0 });
     });
+
+    it('prefers issue_from_id over issue_id when both are present', async () => {
+        window.RedmineCanvasGantt = {
+            projectId: 1,
+            apiBase: '/projects/1/canvas_gantt',
+            redmineBase: '',
+            authToken: 'token',
+            apiKey: 'key'
+        };
+
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                relation: {
+                    id: 4,
+                    issue_id: 99,
+                    issue_from_id: 10,
+                    issue_to_id: 11,
+                    relation_type: 'precedes',
+                    delay: null
+                }
+            })
+        });
+        vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+        const rel = await apiClient.createRelation('10', '11', 'precedes');
+        expect(rel).toEqual({ id: '4', from: '10', to: '11', type: 'precedes', delay: undefined });
+    });
 });
 
 describe('apiClient.updateRelation', () => {

--- a/spa/src/api/client.ts
+++ b/spa/src/api/client.ts
@@ -18,7 +18,7 @@ const normalizeRelation = (raw: unknown, fallback: { fromId: string; toId: strin
     const rel = nested ?? candidate ?? {};
 
     const idValue = rel.id;
-    const fromValue = rel.issue_id ?? rel.issue_from_id ?? rel.from ?? fallback.fromId;
+    const fromValue = rel.issue_from_id ?? rel.issue_id ?? rel.from ?? fallback.fromId;
     const toValue = rel.issue_to_id ?? rel.issue_to ?? rel.to ?? fallback.toId;
     const typeValue = rel.relation_type ?? rel.type ?? fallback.type;
     const delayValue = rel.delay;


### PR DESCRIPTION
### Motivation
- Ensure the relation `from` field is derived from the more specific `issue_from_id` when an API response contains both `issue_id` and `issue_from_id`, avoiding incorrect source assignment.

### Description
- Update `normalizeRelation` in `spa/src/api/client.ts` to check `issue_from_id` before `issue_id` when computing the relation `from` value.
- Add a unit test in `spa/src/api/client.test.ts` to cover the case where both `issue_id` and `issue_from_id` are present and verify `issue_from_id` is preferred.

### Testing
- Ran the unit test updates in `spa/src/api/client.test.ts` with `vitest`, and the updated test suite passed including the new scenario.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aff9d5309483249c71878bc6c9c952)