### PR TITLE
Prefer issue_from_id when parsing relations and handle left-side dependency drags

### DIFF
--- a/spa/src/api/client.test.ts
+++ b/spa/src/api/client.test.ts
@@ -117,6 +117,34 @@ describe('apiClient.createRelation', () => {
         }));
         expect(rel).toEqual({ id: '2', from: '10', to: '11', type: 'precedes', delay: 0 });
     });
+
+    it('prefers issue_from_id over issue_id when both are present', async () => {
+        window.RedmineCanvasGantt = {
+            projectId: 1,
+            apiBase: '/projects/1/canvas_gantt',
+            redmineBase: '',
+            authToken: 'token',
+            apiKey: 'key'
+        };
+
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                relation: {
+                    id: 4,
+                    issue_id: 99,
+                    issue_from_id: 10,
+                    issue_to_id: 11,
+                    relation_type: 'precedes',
+                    delay: null
+                }
+            })
+        });
+        vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+        const rel = await apiClient.createRelation('10', '11', 'precedes');
+        expect(rel).toEqual({ id: '4', from: '10', to: '11', type: 'precedes', delay: undefined });
+    });
 });
 
 describe('apiClient.updateRelation', () => {

--- a/spa/src/api/client.ts
+++ b/spa/src/api/client.ts
@@ -18,7 +18,7 @@ const normalizeRelation = (raw: unknown, fallback: { fromId: string; toId: strin
     const rel = nested ?? candidate ?? {};
 
     const idValue = rel.id;
-    const fromValue = rel.issue_id ?? rel.issue_from_id ?? rel.from ?? fallback.fromId;
+    const fromValue = rel.issue_from_id ?? rel.issue_id ?? rel.from ?? fallback.fromId;
     const toValue = rel.issue_to_id ?? rel.issue_to ?? rel.to ?? fallback.toId;
     const typeValue = rel.relation_type ?? rel.type ?? fallback.type;
     const delayValue = rel.delay;

--- a/spa/src/components/HtmlOverlay.test.tsx
+++ b/spa/src/components/HtmlOverlay.test.tsx
@@ -150,6 +150,38 @@ describe('HtmlOverlay', () => {
         });
     });
 
+
+    it('creates reversed endpoints when dragging from the left dependency handle', async () => {
+        const relation: Relation = { id: 'rel-1', from: '2', to: '1', type: RelationType.Relates };
+        vi.mocked(apiClient.createRelation).mockResolvedValue(relation);
+
+        act(() => {
+            useUIStore.setState({ autoApplyDefaultRelation: false });
+            useTaskStore.getState().setTasks([task1, task2]);
+            useTaskStore.getState().setHoveredTask('1');
+        });
+
+        const { container } = render(<HtmlOverlay />);
+        mockOverlayRect(container);
+
+        const handles = container.querySelectorAll('.dependency-handle');
+        fireEvent.mouseDown(handles[0]);
+
+        const arrangedTask2 = useTaskStore.getState().tasks.find(t => t.id === '2');
+        const bounds2 = LayoutEngine.getTaskBounds(arrangedTask2!, viewport, 'hit', 2);
+        fireEvent.mouseMove(window, { clientX: bounds2.x + 1, clientY: bounds2.y + 1 });
+        fireEvent.mouseUp(window);
+
+        expect(await screen.findByTestId('relation-editor')).toBeInTheDocument();
+        fireEvent.change(screen.getByTestId('relation-type-select'), { target: { value: RelationType.Relates } });
+        fireEvent.click(screen.getByTestId('relation-save-button'));
+
+        await waitFor(() => {
+            expect(apiClient.createRelation).toHaveBeenCalledWith('2', '1', RelationType.Relates, undefined);
+            expect(useTaskStore.getState().relations).toEqual([relation]);
+        });
+    });
+
     it('shows resize handles for a hovered editable leaf task', () => {
         act(() => {
             useTaskStore.getState().setTasks([task1, task2]);

--- a/spa/src/components/HtmlOverlay.tsx
+++ b/spa/src/components/HtmlOverlay.tsx
@@ -387,7 +387,7 @@ export const HtmlOverlay: React.FC = () => {
     const overlayRef = React.useRef<HTMLDivElement>(null);
     const contextMenuRef = React.useRef<HTMLDivElement>(null);
     const relationMenuRef = React.useRef<HTMLDivElement | null>(null);
-    const [dragDraft, setDragDraft] = React.useState<{ fromId: string; start: { x: number; y: number }; pointer: { x: number; y: number }; targetId?: string } | null>(null);
+    const [dragDraft, setDragDraft] = React.useState<{ fromId: string; start: { x: number; y: number }; pointer: { x: number; y: number }; startSide: 'left' | 'right'; targetId?: string } | null>(null);
     const dragDraftRef = React.useRef<typeof dragDraft>(null);
     const [menuPosition, setMenuPosition] = React.useState<{ x: number; y: number } | null>(null);
     const [relationPosition, setRelationPosition] = React.useState<{ x: number; y: number } | null>(null);
@@ -524,17 +524,20 @@ export const HtmlOverlay: React.FC = () => {
         dragDraftRef.current = null;
         setDragDraft(null);
 
-        const { fromId, targetId, start, pointer } = currentDraft;
+        const { fromId, targetId, start, pointer, startSide } = currentDraft;
         if (!targetId || targetId === fromId) return;
 
-        const fromTask = taskById.get(fromId);
-        const toTask = taskById.get(targetId);
+        const relationFromId = startSide === 'left' ? targetId : fromId;
+        const relationToId = startSide === 'left' ? fromId : targetId;
+
+        const fromTask = taskById.get(relationFromId);
+        const toTask = taskById.get(relationToId);
         const autoDelay = autoCalculateDelay && defaultRelationType === RelationType.Precedes
             ? calculateDelay(RelationType.Precedes, fromTask, toTask)
             : {};
 
         const duplicate = relations.some((relation) => (
-            relation.from === fromId && relation.to === targetId && relation.type === defaultRelationType
+            relation.from === relationFromId && relation.to === relationToId && relation.type === defaultRelationType
         ));
         if (duplicate) {
             useUIStore.getState().addNotification(i18n.t('label_relation_already_exists') || 'Relation already exists', 'warning');
@@ -544,7 +547,7 @@ export const HtmlOverlay: React.FC = () => {
         const relationDelay = defaultRelationType === RelationType.Precedes ? autoDelay.delay : undefined;
 
         if (autoApplyDefaultRelation) {
-            void handleCreateRelation({ from: fromId, to: targetId, type: defaultRelationType }, defaultRelationType, relationDelay).catch((error: unknown) => {
+            void handleCreateRelation({ from: relationFromId, to: relationToId, type: defaultRelationType }, defaultRelationType, relationDelay).catch((error: unknown) => {
                 const message = error instanceof Error ? error.message : (i18n.t('label_relation_add_failed') || 'Failed to create relation');
                 useUIStore.getState().addNotification(message, 'error');
             });
@@ -552,8 +555,8 @@ export const HtmlOverlay: React.FC = () => {
         }
 
         setDraftRelation({
-            from: fromId,
-            to: targetId,
+            from: relationFromId,
+            to: relationToId,
             type: defaultRelationType,
             delay: relationDelay,
             autoDelayMessage: defaultRelationType === RelationType.Precedes ? autoDelay.message : undefined,
@@ -564,9 +567,9 @@ export const HtmlOverlay: React.FC = () => {
         });
     }, [autoApplyDefaultRelation, autoCalculateDelay, defaultRelationType, handleCreateRelation, handleMouseMove, relations, setDraftRelation, taskById]);
 
-    const startDraft = React.useCallback((taskId: string, x: number, y: number) => {
+    const startDraft = React.useCallback((taskId: string, x: number, y: number, startSide: 'left' | 'right') => {
         const startPoint = { x, y };
-        setDragDraftState({ fromId: taskId, start: startPoint, pointer: startPoint });
+        setDragDraftState({ fromId: taskId, start: startPoint, pointer: startPoint, startSide });
         window.addEventListener('mousemove', handleMouseMove);
         window.addEventListener('mouseup', handleMouseUp);
     }, [handleMouseMove, handleMouseUp, setDragDraftState]);
@@ -872,14 +875,14 @@ export const HtmlOverlay: React.FC = () => {
                                         className="dependency-handle"
                                         style={{ ...baseStyle, left: bounds.x - handleOffset - 5 }}
                                         onMouseDown={() => {
-                                            startDraft(task.id, bounds.x, centerY);
+                                            startDraft(task.id, bounds.x, centerY, 'left');
                                         }}
                                     />
                                     <div
                                         className="dependency-handle"
                                         style={{ ...baseStyle, left: bounds.x + bounds.width + handleOffset - 5 }}
                                         onMouseDown={() => {
-                                            startDraft(task.id, bounds.x + bounds.width, centerY);
+                                            startDraft(task.id, bounds.x + bounds.width, centerY, 'right');
                                         }}
                                     />
                                 </>


### PR DESCRIPTION
### Motivation
- Ensure relation parsing prefers `issue_from_id` when both `issue_id` and `issue_from_id` are returned by the API to avoid incorrect endpoint mapping. 
- Fix relation creation UX so dragging from the left dependency handle creates a relation with reversed endpoints compared to dragging from the right handle.

### Description
- Change `normalizeRelation` to prefer `issue_from_id` over `issue_id` when deriving the relation `from` value. 
- Extend the drag state to include a `startSide` (`'left' | 'right'`) and thread it through `startDraft`, `dragDraft`, and the drag handlers. 
- Update `handleMouseUp` logic to compute `relationFromId` and `relationToId` based on `startSide`, adjust duplicate checks, and use the corrected endpoints for auto-apply and draft creation. 
- Add unit tests to cover preferring `issue_from_id` and creating reversed endpoints when dragging from the left dependency handle.

### Testing
- Ran the unit test suite with `vitest` which includes the updated tests for relation parsing and left-handle dragging, and all tests succeeded. 
- Verified the updated `HtmlOverlay` drag-related tests pass locally under the component test harness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aff9d5309483249c71878bc6c9c952)