### PR TITLE
Codex/fix multi project edit behavior in canvas gantt

### DIFF
--- a/app/controllers/canvas_gantts_controller.rb
+++ b/app/controllers/canvas_gantts_controller.rb
@@ -302,6 +302,7 @@ class CanvasGanttsController < ApplicationController
   require_dependency Rails.root.join('plugins', 'redmine_canvas_gantt', 'lib', 'redmine_canvas_gantt', 'bulk_subtask_creator').to_s
   require_dependency Rails.root.join('plugins', 'redmine_canvas_gantt', 'lib', 'redmine_canvas_gantt', 'parent_issue_resolver').to_s
   require_dependency Rails.root.join('plugins', 'redmine_canvas_gantt', 'lib', 'redmine_canvas_gantt', 'query_state_resolver').to_s
+  require_dependency Rails.root.join('plugins', 'redmine_canvas_gantt', 'lib', 'redmine_canvas_gantt', 'view_scope_resolver').to_s
   require_dependency Rails.root.join('plugins', 'redmine_canvas_gantt', 'lib', 'redmine_canvas_gantt', 'baseline_task_state').to_s
   require_dependency Rails.root.join('plugins', 'redmine_canvas_gantt', 'lib', 'redmine_canvas_gantt', 'baseline_snapshot').to_s
   require_dependency Rails.root.join('plugins', 'redmine_canvas_gantt', 'lib', 'redmine_canvas_gantt', 'baseline_repository').to_s
@@ -309,12 +310,11 @@ class CanvasGanttsController < ApplicationController
   helper RedmineCanvasGantt::ViteAssetHelper
   accept_api_auth :data, :queries, :edit_meta, :update, :bulk_create_subtasks, :create_relation, :update_relation, :destroy_relation, :save_baseline
 
-  before_action :find_project_by_project_id
+  before_action :resolve_canvas_project
   before_action :set_permissions
   before_action :ensure_view_permission, only: [:index, :data, :queries, :edit_meta]
-  before_action :ensure_edit_permission, only: [:update, :bulk_create_subtasks, :update_relation, :destroy_relation]
   skip_forgery_protection only: [:asset]
-  skip_before_action :find_project_by_project_id, :set_permissions, only: [:asset]
+  skip_before_action :resolve_canvas_project, :set_permissions, only: [:asset]
 
   # GET /plugin_assets/redmine_canvas_gantt/build/*asset_path
   # Fallback asset delivery when public/plugin_assets static serving is disabled.
@@ -414,7 +414,7 @@ class CanvasGanttsController < ApplicationController
     issue = Issue.visible.find(params[:id])
     return unless ensure_issue_in_scope(issue)
 
-    editable = @permissions[:editable] && issue.editable?
+    editable = User.current.allowed_to?(:edit_issues, issue.project) && issue.editable?
     field_editable = build_field_editable(issue, editable)
     custom_fields, custom_field_values = custom_field_extractor.extract_custom_fields(
       issue,
@@ -426,7 +426,8 @@ class CanvasGanttsController < ApplicationController
       editable: field_editable,
       custom_fields: custom_fields,
       custom_field_values: custom_field_values,
-      permissions: @permissions
+      permissions: @permissions,
+      visible_project_ids: current_view_scope[:visible_project_ids]
     )
   rescue ActiveRecord::RecordNotFound
     render json: { error: canvas_gantt_l(:error_canvas_gantt_task_not_found) }, status: :not_found
@@ -445,6 +446,7 @@ class CanvasGanttsController < ApplicationController
     # Optimistic Locking Check handled by ActiveRecord automatically if lock_version is present
     issue.init_journal(User.current)
     issue.safe_attributes = permitted_task_params
+    return unless ensure_project_move_valid!(issue)
 
     if issue.save
       if requested_parent_issue_id_provided? && issue.parent_id != requested_parent_issue_id
@@ -559,11 +561,21 @@ class CanvasGanttsController < ApplicationController
     false
   end
 
-  def ensure_edit_permission
-    unless @permissions[:editable]
-      render json: { error: canvas_gantt_l(:error_canvas_gantt_permission_denied) }, status: :forbidden
-      return false
+  def resolve_canvas_project
+    if request.path_parameters[:project_id].present?
+      find_project_by_project_id
+      return
     end
+
+    project_id = params[:canvas_project_id]
+    if project_id.present?
+      @project = Project.visible.find(project_id)
+      return
+    end
+
+    render json: { error: canvas_gantt_l(:error_canvas_gantt_permission_denied) }, status: :forbidden
+  rescue ActiveRecord::RecordNotFound
+    render_404
   end
 
   def ensure_baseline_edit_permission
@@ -695,14 +707,14 @@ class CanvasGanttsController < ApplicationController
   end
 
   def ensure_issue_in_scope(issue)
-    return true if descendant_project_ids.include?(issue.project_id)
+    return true if current_view_issue_ids.include?(issue.id)
 
     render json: { error: canvas_gantt_l(:error_canvas_gantt_issue_not_found_in_project) }, status: :not_found
     false
   end
 
   def ensure_issue_editable(issue)
-    return true if User.current.allowed_to?(:edit_issues, issue.project) && issue.editable?
+    return true if issue_editable?(issue)
 
     render json: { error: canvas_gantt_l(:error_canvas_gantt_permission_denied) }, status: :forbidden
     false
@@ -736,13 +748,12 @@ class CanvasGanttsController < ApplicationController
       return false
     end
 
-    owned_issue = [issue_from, issue_to].find { |issue| descendant_project_ids.include?(issue.project_id) }
-    unless owned_issue
+    unless current_view_issue_ids.include?(issue_from.id) && current_view_issue_ids.include?(issue_to.id)
       render json: { error: canvas_gantt_l(:error_canvas_gantt_relation_not_found_in_project) }, status: :not_found
       return false
     end
 
-    unless @permissions[:editable] && owned_issue.editable?
+    unless issue_editable?(issue_from) && issue_editable?(issue_to)
       render json: { error: canvas_gantt_l(:error_canvas_gantt_permission_denied) }, status: :forbidden
       return false
     end
@@ -753,13 +764,14 @@ class CanvasGanttsController < ApplicationController
   def ensure_relation_createable!(issue_from, issue_to)
     return false unless ensure_issue_in_scope(issue_from)
     return false unless ensure_issue_in_scope(issue_to)
-
-    unless @permissions[:editable] && issue_from.editable?
-      render json: { error: canvas_gantt_l(:error_canvas_gantt_permission_denied) }, status: :forbidden
-      return false
-    end
+    return false unless ensure_issue_editable(issue_from)
+    return false unless ensure_issue_editable(issue_to)
 
     true
+  end
+
+  def issue_editable?(issue)
+    User.current.allowed_to?(:edit_issues, issue.project) && issue.editable?
   end
 
   def relation_non_working_week_days
@@ -786,7 +798,7 @@ class CanvasGanttsController < ApplicationController
       issue_to: issue_to,
       relation_type: relation_type,
       delay: delay,
-      existing_relations: data_payload_builder.build_relations(issue_scope(descendant_project_ids).to_a),
+      existing_relations: build_relations(current_view_scope[:issues]),
       candidate_relation: build_candidate_relation(
         relation_id: relation_id,
         issue_from: issue_from,
@@ -922,5 +934,53 @@ class CanvasGanttsController < ApplicationController
 
   def parent_issue_resolver
     @parent_issue_resolver ||= RedmineCanvasGantt::ParentIssueResolver.new
+  end
+
+  def build_relations(issues)
+    data_payload_builder.build_relations(issues)
+  end
+
+  def current_view_scope
+    @current_view_scope ||= RedmineCanvasGantt::ViewScopeResolver.new(
+      project: @project,
+      params: params,
+      current_user: User.current,
+      issue_includes: ISSUE_INCLUDES
+    ).resolve
+  end
+
+  def current_view_issue_ids
+    current_view_scope[:issue_ids]
+  end
+
+  def ensure_project_move_valid!(issue)
+    destination_project = issue.project
+    return true unless destination_project
+    return true unless permitted_task_params.key?(:project_id) || permitted_task_params.key?('project_id')
+
+    unless current_view_scope[:visible_project_ids].include?(destination_project.id) &&
+           User.current.allowed_to?(:add_issues, destination_project)
+      render json: { error: canvas_gantt_l(:error_canvas_gantt_permission_denied) }, status: :forbidden
+      return false
+    end
+
+    unless destination_project.trackers.include?(issue.tracker)
+      issue.errors.add(:tracker, :invalid)
+      render json: { errors: issue.errors.full_messages }, status: :unprocessable_entity
+      return false
+    end
+
+    if issue.assigned_to_id.present? && !issue.assignable_users.map(&:id).include?(issue.assigned_to_id)
+      issue.errors.add(:assigned_to, :invalid)
+      render json: { errors: issue.errors.full_messages }, status: :unprocessable_entity
+      return false
+    end
+
+    issue.fixed_version = nil if issue.fixed_version && issue.fixed_version.project_id != destination_project.id
+    if issue.category && issue.category.project_id != destination_project.id
+      issue.category = nil
+    end
+
+    true
   end
 end

--- a/app/controllers/canvas_gantts_controller.rb
+++ b/app/controllers/canvas_gantts_controller.rb
@@ -945,7 +945,10 @@ class CanvasGanttsController < ApplicationController
       project: @project,
       params: params,
       current_user: User.current,
-      issue_includes: ISSUE_INCLUDES
+      issue_includes: ISSUE_INCLUDES,
+      member_project_ids_resolver: lambda {
+        visible_member_projects.map(&:id)
+      }
     ).resolve
   end
 

--- a/app/controllers/canvas_gantts_controller.rb
+++ b/app/controllers/canvas_gantts_controller.rb
@@ -427,7 +427,7 @@ class CanvasGanttsController < ApplicationController
       custom_fields: custom_fields,
       custom_field_values: custom_field_values,
       permissions: @permissions,
-      visible_project_ids: current_view_scope[:scope_project_ids]
+      project_scope_ids: current_view_scope[:scope_project_ids]
     )
   rescue ActiveRecord::RecordNotFound
     render json: { error: canvas_gantt_l(:error_canvas_gantt_task_not_found) }, status: :not_found

--- a/app/controllers/canvas_gantts_controller.rb
+++ b/app/controllers/canvas_gantts_controller.rb
@@ -427,7 +427,7 @@ class CanvasGanttsController < ApplicationController
       custom_fields: custom_fields,
       custom_field_values: custom_field_values,
       permissions: @permissions,
-      visible_project_ids: current_view_scope[:visible_project_ids]
+      visible_project_ids: current_view_scope[:scope_project_ids]
     )
   rescue ActiveRecord::RecordNotFound
     render json: { error: canvas_gantt_l(:error_canvas_gantt_task_not_found) }, status: :not_found
@@ -961,7 +961,7 @@ class CanvasGanttsController < ApplicationController
     return true unless destination_project
     return true unless permitted_task_params.key?(:project_id) || permitted_task_params.key?('project_id')
 
-    unless current_view_scope[:visible_project_ids].include?(destination_project.id) &&
+    unless current_view_scope[:scope_project_ids].include?(destination_project.id) &&
            User.current.allowed_to?(:add_issues, destination_project)
       render json: { error: canvas_gantt_l(:error_canvas_gantt_permission_denied) }, status: :forbidden
       return false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,4 +14,11 @@ RedmineApp::Application.routes.draw do
     patch 'canvas_gantt/relations/:id', to: 'canvas_gantts#update_relation'
     delete 'canvas_gantt/relations/:id', to: 'canvas_gantts#destroy_relation'
   end
+
+  get '/canvas_gantt/tasks/:id/edit_meta', to: 'canvas_gantts#edit_meta'
+  patch '/canvas_gantt/tasks/:id', to: 'canvas_gantts#update'
+  post '/canvas_gantt/subtasks/bulk', to: 'canvas_gantts#bulk_create_subtasks'
+  post '/canvas_gantt/relations', to: 'canvas_gantts#create_relation'
+  patch '/canvas_gantt/relations/:id', to: 'canvas_gantts#update_relation'
+  delete '/canvas_gantt/relations/:id', to: 'canvas_gantts#destroy_relation'
 end

--- a/lib/redmine_canvas_gantt/data_payload_builder.rb
+++ b/lib/redmine_canvas_gantt/data_payload_builder.rb
@@ -62,7 +62,10 @@ module RedmineCanvasGantt
     end
 
     def build_relations(issues)
-      issues.flat_map(&:relations).uniq.map do |relation|
+      visible_ids = issues.map(&:id).to_set
+      issues.flat_map(&:relations).uniq.filter do |relation|
+        visible_ids.include?(relation.issue_from_id) && visible_ids.include?(relation.issue_to_id)
+      end.map do |relation|
         serialize_relation(relation)
       end
     end

--- a/lib/redmine_canvas_gantt/edit_meta_payload_builder.rb
+++ b/lib/redmine_canvas_gantt/edit_meta_payload_builder.rb
@@ -7,7 +7,7 @@ module RedmineCanvasGantt
       @version_class = version_class
     end
 
-    def build(issue:, editable:, custom_fields:, custom_field_values:, permissions:, visible_project_ids:)
+    def build(issue:, editable:, custom_fields:, custom_field_values:, permissions:, project_scope_ids:)
       {
         task: {
           id: issue.id,
@@ -33,7 +33,7 @@ module RedmineCanvasGantt
             { id: priority.id, name: priority.name, position: priority.position }
           end,
           categories: issue.project.issue_categories.map { |category| { id: category.id, name: category.name } },
-          projects: project_options_for(visible_project_ids),
+          projects: project_options_for(project_scope_ids),
           trackers: issue.project.trackers.map { |tracker| { id: tracker.id, name: tracker.name } },
           versions: @version_class.visible.where(project_id: issue.project_id).map { |version| { id: version.id, name: version.name } },
           custom_fields: custom_fields
@@ -57,10 +57,10 @@ module RedmineCanvasGantt
         .map { |user| { id: user.id, name: user.name } }
     end
 
-    def project_options_for(visible_project_ids)
+    def project_options_for(project_scope_ids)
       @project_class.allowed_to(:add_issues)
         .active
-        .where(id: visible_project_ids)
+        .where(id: project_scope_ids)
         .map { |project| { id: project.id, name: project.name } }
     end
   end

--- a/lib/redmine_canvas_gantt/edit_meta_payload_builder.rb
+++ b/lib/redmine_canvas_gantt/edit_meta_payload_builder.rb
@@ -7,7 +7,7 @@ module RedmineCanvasGantt
       @version_class = version_class
     end
 
-    def build(issue:, editable:, custom_fields:, custom_field_values:, permissions:)
+    def build(issue:, editable:, custom_fields:, custom_field_values:, permissions:, visible_project_ids:)
       {
         task: {
           id: issue.id,
@@ -16,6 +16,13 @@ module RedmineCanvasGantt
           status_id: issue.status_id,
           done_ratio: issue.done_ratio,
           due_date: issue.due_date,
+          start_date: issue.start_date,
+          priority_id: issue.priority_id,
+          category_id: issue.category_id,
+          estimated_hours: issue.estimated_hours,
+          project_id: issue.project_id,
+          tracker_id: issue.tracker_id,
+          fixed_version_id: issue.fixed_version_id,
           lock_version: issue.lock_version
         },
         editable: editable,
@@ -26,7 +33,7 @@ module RedmineCanvasGantt
             { id: priority.id, name: priority.name, position: priority.position }
           end,
           categories: issue.project.issue_categories.map { |category| { id: category.id, name: category.name } },
-          projects: @project_class.allowed_to(:add_issues).active.map { |project| { id: project.id, name: project.name } },
+          projects: project_options_for(visible_project_ids),
           trackers: issue.project.trackers.map { |tracker| { id: tracker.id, name: tracker.name } },
           versions: @version_class.visible.where(project_id: issue.project_id).map { |version| { id: version.id, name: version.name } },
           custom_fields: custom_fields
@@ -48,6 +55,13 @@ module RedmineCanvasGantt
       issue.assignable_users.to_a
         .sort_by { |user| user.name.to_s.downcase }
         .map { |user| { id: user.id, name: user.name } }
+    end
+
+    def project_options_for(visible_project_ids)
+      @project_class.allowed_to(:add_issues)
+        .active
+        .where(id: visible_project_ids)
+        .map { |project| { id: project.id, name: project.name } }
     end
   end
 end

--- a/lib/redmine_canvas_gantt/view_scope_resolver.rb
+++ b/lib/redmine_canvas_gantt/view_scope_resolver.rb
@@ -2,15 +2,16 @@ require 'set'
 
 module RedmineCanvasGantt
   class ViewScopeResolver
-    def initialize(project:, params:, current_user:, issue_includes:)
+    def initialize(project:, params:, current_user:, issue_includes:, member_project_ids_resolver: nil)
       @project = project
       @params = params
       @current_user = current_user
       @issue_includes = issue_includes
+      @member_project_ids_resolver = member_project_ids_resolver
     end
 
     def resolve
-      query_resolution = query_state_resolver.resolve(project_ids: descendant_project_ids)
+      query_resolution = query_state_resolver.resolve(project_ids: base_project_ids)
       issues = query_resolution[:issues]
       issue_ids = issues.map(&:id).to_set
       visible_project_ids = issues.map(&:project_id).uniq
@@ -38,6 +39,26 @@ module RedmineCanvasGantt
 
     def descendant_project_ids
       @descendant_project_ids ||= @project.self_and_descendants.pluck(:id)
+    end
+
+    def base_project_ids
+      return descendant_project_ids unless member_projects_only?
+
+      member_project_ids
+    end
+
+    def member_projects_only?
+      ActiveModel::Type::Boolean.new.cast(@params[:member_projects_only])
+    end
+
+    def member_project_ids
+      ids = if @member_project_ids_resolver
+              Array(@member_project_ids_resolver.call)
+            else
+              []
+            end
+
+      ids.map(&:to_i).select(&:positive?).uniq
     end
   end
 end

--- a/lib/redmine_canvas_gantt/view_scope_resolver.rb
+++ b/lib/redmine_canvas_gantt/view_scope_resolver.rb
@@ -64,10 +64,11 @@ module RedmineCanvasGantt
     end
 
     def scope_project_ids
+      base_ids = base_project_ids
       explicit_ids = parse_integer_list(@params[:project_ids])
-      return explicit_ids if explicit_ids.present?
+      return base_ids if explicit_ids.blank?
 
-      base_project_ids
+      explicit_ids & base_ids
     end
 
     def parse_integer_list(values)

--- a/lib/redmine_canvas_gantt/view_scope_resolver.rb
+++ b/lib/redmine_canvas_gantt/view_scope_resolver.rb
@@ -1,0 +1,43 @@
+require 'set'
+
+module RedmineCanvasGantt
+  class ViewScopeResolver
+    def initialize(project:, params:, current_user:, issue_includes:)
+      @project = project
+      @params = params
+      @current_user = current_user
+      @issue_includes = issue_includes
+    end
+
+    def resolve
+      query_resolution = query_state_resolver.resolve(project_ids: descendant_project_ids)
+      issues = query_resolution[:issues]
+      issue_ids = issues.map(&:id).to_set
+      visible_project_ids = issues.map(&:project_id).uniq
+
+      {
+        issues: issues,
+        issue_ids: issue_ids,
+        visible_project_ids: visible_project_ids,
+        initial_state: query_resolution[:initial_state],
+        warnings: query_resolution[:warnings]
+      }
+    end
+
+    private
+
+    def query_state_resolver
+      @query_state_resolver ||= RedmineCanvasGantt::QueryStateResolver.new(
+        project: @project,
+        params: @params,
+        current_user: @current_user,
+        issue_scope: Issue.visible,
+        issue_includes: @issue_includes
+      )
+    end
+
+    def descendant_project_ids
+      @descendant_project_ids ||= @project.self_and_descendants.pluck(:id)
+    end
+  end
+end

--- a/lib/redmine_canvas_gantt/view_scope_resolver.rb
+++ b/lib/redmine_canvas_gantt/view_scope_resolver.rb
@@ -11,7 +11,8 @@ module RedmineCanvasGantt
     end
 
     def resolve
-      query_resolution = query_state_resolver.resolve(project_ids: base_project_ids)
+      resolved_scope_project_ids = scope_project_ids
+      query_resolution = query_state_resolver.resolve(project_ids: resolved_scope_project_ids)
       issues = query_resolution[:issues]
       issue_ids = issues.map(&:id).to_set
       visible_project_ids = issues.map(&:project_id).uniq
@@ -19,6 +20,7 @@ module RedmineCanvasGantt
       {
         issues: issues,
         issue_ids: issue_ids,
+        scope_project_ids: resolved_scope_project_ids,
         visible_project_ids: visible_project_ids,
         initial_state: query_resolution[:initial_state],
         warnings: query_resolution[:warnings]
@@ -59,6 +61,21 @@ module RedmineCanvasGantt
             end
 
       ids.map(&:to_i).select(&:positive?).uniq
+    end
+
+    def scope_project_ids
+      explicit_ids = parse_integer_list(@params[:project_ids])
+      return explicit_ids if explicit_ids.present?
+
+      base_project_ids
+    end
+
+    def parse_integer_list(values)
+      Array(values)
+        .flat_map { |value| value.to_s.split(/[|,]/) }
+        .filter_map { |value| Integer(value, exception: false) }
+        .select(&:positive?)
+        .uniq
     end
   end
 end

--- a/spa/src/api/client.test.ts
+++ b/spa/src/api/client.test.ts
@@ -275,7 +275,7 @@ describe('apiClient.createRelation', () => {
         vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
 
         const rel = await apiClient.createRelation('10', '11', 'precedes');
-        expect(fetchMock).toHaveBeenCalledWith('/projects/1/canvas_gantt/relations.json', expect.objectContaining({
+        expect(fetchMock).toHaveBeenCalledWith('/canvas_gantt/relations.json?canvas_project_id=1', expect.objectContaining({
             method: 'POST'
         }));
         expect(rel).toEqual({ id: '1', from: '10', to: '11', type: 'precedes', delay: undefined });
@@ -297,7 +297,7 @@ describe('apiClient.createRelation', () => {
         vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
 
         const rel = await apiClient.createRelation('10', '11', 'precedes');
-        expect(fetchMock).toHaveBeenCalledWith('/projects/1/canvas_gantt/relations.json', expect.objectContaining({
+        expect(fetchMock).toHaveBeenCalledWith('/canvas_gantt/relations.json?canvas_project_id=1', expect.objectContaining({
             method: 'POST'
         }));
         expect(rel).toEqual({ id: '2', from: '10', to: '11', type: 'precedes', delay: 0 });
@@ -357,7 +357,7 @@ describe('apiClient.updateRelation', () => {
 
         const rel = await apiClient.updateRelation('3', 'blocks');
 
-        expect(fetchMock).toHaveBeenCalledWith('/projects/1/canvas_gantt/relations/3.json', expect.objectContaining({
+        expect(fetchMock).toHaveBeenCalledWith('/canvas_gantt/relations/3.json?canvas_project_id=1', expect.objectContaining({
             method: 'PATCH'
         }));
         expect(rel).toEqual({ id: '3', from: '10', to: '11', type: 'blocks', delay: undefined });

--- a/spa/src/api/client.ts
+++ b/spa/src/api/client.ts
@@ -115,6 +115,17 @@ const getConfig = (): RedmineCanvasGanttConfig => {
     return config;
 };
 
+const getGlobalApiBase = (config: RedmineCanvasGanttConfig): string => {
+    const redmineBase = (config.redmineBase || '').replace(/\/$/, '');
+    return `${redmineBase}/canvas_gantt`;
+};
+
+const buildViewContextQuery = (config: RedmineCanvasGanttConfig): string => {
+    const params = new URLSearchParams(window.location.search);
+    params.set('canvas_project_id', String(config.projectId));
+    return params.toString();
+};
+
 const buildJsonHeaders = (config: RedmineCanvasGanttConfig, includeCsrf: boolean = false): HeadersInit => ({
     'X-Redmine-API-Key': config.apiKey,
     'Content-Type': 'application/json',
@@ -592,8 +603,8 @@ export const apiClient = {
 
     fetchEditMeta: async (taskId: string): Promise<TaskEditMeta> => {
         const config = getConfig();
-
-        const response = await fetch(`${config.apiBase}/tasks/${taskId}/edit_meta.json`, {
+        const query = buildViewContextQuery(config);
+        const response = await fetch(`${getGlobalApiBase(config)}/tasks/${taskId}/edit_meta.json?${query}`, {
             headers: buildJsonHeaders(config)
         });
 
@@ -678,17 +689,17 @@ export const apiClient = {
                 id: String(taskIdValue),
                 subject: String(subjectValue),
                 assignedToId: typeof assignedToIdValue === 'number' ? assignedToIdValue : null,
-                statusId: typeof statusIdValue === 'number' ? statusIdValue : Number(statusIdValue),
-                doneRatio: typeof doneRatioValue === 'number' ? doneRatioValue : Number(doneRatioValue),
+                statusId: typeof statusIdValue === 'number' ? statusIdValue : Number(statusIdValue || 0),
+                doneRatio: typeof doneRatioValue === 'number' ? doneRatioValue : Number(doneRatioValue || 0),
                 dueDate: typeof dueDateValue === 'string' ? dueDateValue : null,
                 startDate: typeof startDateValue === 'string' ? startDateValue : null,
-                priorityId: typeof priorityIdValue === 'number' ? priorityIdValue : Number(priorityIdValue),
+                priorityId: typeof priorityIdValue === 'number' ? priorityIdValue : Number(priorityIdValue || 0),
                 categoryId: typeof categoryIdValue === 'number' ? categoryIdValue : (categoryIdValue ? Number(categoryIdValue) : null),
                 estimatedHours: typeof estimatedHoursValue === 'number' ? estimatedHoursValue : (estimatedHoursValue ? Number(estimatedHoursValue) : null),
-                projectId: typeof projectIdValue === 'number' ? projectIdValue : Number(projectIdValue),
-                trackerId: typeof trackerIdValue === 'number' ? trackerIdValue : Number(trackerIdValue),
+                projectId: typeof projectIdValue === 'number' ? projectIdValue : Number(projectIdValue || 0),
+                trackerId: typeof trackerIdValue === 'number' ? trackerIdValue : Number(trackerIdValue || 0),
                 fixedVersionId: typeof fixedVersionIdValue === 'number' ? fixedVersionIdValue : (fixedVersionIdValue ? Number(fixedVersionIdValue) : null),
-                lockVersion: typeof lockVersionValue === 'number' ? lockVersionValue : Number(lockVersionValue)
+                lockVersion: typeof lockVersionValue === 'number' ? lockVersionValue : Number(lockVersionValue || 0)
             },
             editable: {
                 subject: editableSubject as boolean,
@@ -721,8 +732,9 @@ export const apiClient = {
 
     updateTask: async (task: Task): Promise<UpdateTaskResult> => {
         const config = getConfig();
+        const query = buildViewContextQuery(config);
 
-        const response = await fetch(`${config.apiBase}/tasks/${task.id}.json`, {
+        const response = await fetch(`${getGlobalApiBase(config)}/tasks/${task.id}.json?${query}`, {
             method: 'PATCH',
             headers: buildJsonHeaders(config, true),
             body: JSON.stringify({
@@ -755,8 +767,9 @@ export const apiClient = {
 
     updateTaskFields: async (taskId: string, fields: Record<string, unknown>): Promise<UpdateTaskResult> => {
         const config = getConfig();
+        const query = buildViewContextQuery(config);
 
-        const response = await fetch(`${config.apiBase}/tasks/${taskId}.json`, {
+        const response = await fetch(`${getGlobalApiBase(config)}/tasks/${taskId}.json?${query}`, {
             method: 'PATCH',
             headers: buildJsonHeaders(config, true),
             body: JSON.stringify({ task: fields })
@@ -782,8 +795,9 @@ export const apiClient = {
 
     createRelation: async (fromId: string, toId: string, type: string, delay?: number): Promise<Relation> => {
         const config = getConfig();
+        const query = buildViewContextQuery(config);
 
-        const response = await fetch(`${config.apiBase}/relations.json`, {
+        const response = await fetch(`${getGlobalApiBase(config)}/relations.json?${query}`, {
             method: 'POST',
             headers: buildJsonHeaders(config, true),
             body: JSON.stringify({
@@ -815,7 +829,8 @@ export const apiClient = {
 
     updateRelation: async (relationId: string, type: string, delay?: number): Promise<Relation> => {
         const config = getConfig();
-        const response = await fetch(`${config.apiBase}/relations/${relationId}.json`, {
+        const query = buildViewContextQuery(config);
+        const response = await fetch(`${getGlobalApiBase(config)}/relations/${relationId}.json?${query}`, {
             method: 'PATCH',
             headers: buildJsonHeaders(config, true),
             body: JSON.stringify({
@@ -836,8 +851,9 @@ export const apiClient = {
 
     deleteRelation: async (relationId: string): Promise<void> => {
         const config = getConfig();
+        const query = buildViewContextQuery(config);
 
-        const response = await fetch(`${config.apiBase}/relations/${relationId}.json`, {
+        const response = await fetch(`${getGlobalApiBase(config)}/relations/${relationId}.json?${query}`, {
             method: 'DELETE',
             headers: buildJsonHeaders(config, true)
         });
@@ -850,7 +866,8 @@ export const apiClient = {
 
     bulkCreateSubtasks: async (payload: { parentId: string; subjects: string[] }): Promise<BulkCreateSubtasksResult> => {
         const config = getConfig();
-        const response = await fetch(`${config.apiBase}/subtasks/bulk.json`, {
+        const query = buildViewContextQuery(config);
+        const response = await fetch(`${getGlobalApiBase(config)}/subtasks/bulk.json?${query}`, {
             method: 'POST',
             headers: buildJsonHeaders(config, true),
             body: JSON.stringify({

--- a/spa/src/api/client.ts
+++ b/spa/src/api/client.ts
@@ -160,7 +160,14 @@ const parseEditOption = (value: unknown): EditOption | null => {
     };
 };
 
+const isBlankRequiredValue = (value: unknown): boolean =>
+    value === null || value === undefined || value === '';
+
 const parseRequiredPositiveNumber = (value: unknown, fieldName: string): number => {
+    if (isBlankRequiredValue(value)) {
+        throw new Error(`Invalid response: ${fieldName}`);
+    }
+
     const parsed = typeof value === 'number' ? value : Number(value);
     if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
         throw new Error(`Invalid response: ${fieldName}`);
@@ -168,17 +175,25 @@ const parseRequiredPositiveNumber = (value: unknown, fieldName: string): number 
     return parsed;
 };
 
-const parseRequiredNonNegativeNumber = (value: unknown, fieldName: string): number => {
+const parseRequiredNonNegativeInteger = (value: unknown, fieldName: string): number => {
+    if (isBlankRequiredValue(value)) {
+        throw new Error(`Invalid response: ${fieldName}`);
+    }
+
     const parsed = typeof value === 'number' ? value : Number(value);
-    if (!Number.isFinite(parsed) || parsed < 0) {
+    if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) {
         throw new Error(`Invalid response: ${fieldName}`);
     }
     return parsed;
 };
 
 const parseRequiredDoneRatio = (value: unknown): number => {
+    if (isBlankRequiredValue(value)) {
+        throw new Error('Invalid response: done_ratio');
+    }
+
     const parsed = typeof value === 'number' ? value : Number(value);
-    if (!Number.isFinite(parsed) || parsed < 0 || parsed > 100) {
+    if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0 || parsed > 100) {
         throw new Error('Invalid response: done_ratio');
     }
     return parsed;
@@ -725,7 +740,7 @@ export const apiClient = {
                 projectId: parseRequiredPositiveNumber(projectIdValue, 'project_id'),
                 trackerId: parseRequiredPositiveNumber(trackerIdValue, 'tracker_id'),
                 fixedVersionId: typeof fixedVersionIdValue === 'number' ? fixedVersionIdValue : (fixedVersionIdValue ? Number(fixedVersionIdValue) : null),
-                lockVersion: parseRequiredNonNegativeNumber(lockVersionValue, 'lock_version')
+                lockVersion: parseRequiredNonNegativeInteger(lockVersionValue, 'lock_version')
             },
             editable: {
                 subject: editableSubject as boolean,

--- a/spa/src/api/client.ts
+++ b/spa/src/api/client.ts
@@ -160,6 +160,30 @@ const parseEditOption = (value: unknown): EditOption | null => {
     };
 };
 
+const parseRequiredPositiveNumber = (value: unknown, fieldName: string): number => {
+    const parsed = typeof value === 'number' ? value : Number(value);
+    if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+        throw new Error(`Invalid response: ${fieldName}`);
+    }
+    return parsed;
+};
+
+const parseRequiredNonNegativeNumber = (value: unknown, fieldName: string): number => {
+    const parsed = typeof value === 'number' ? value : Number(value);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+        throw new Error(`Invalid response: ${fieldName}`);
+    }
+    return parsed;
+};
+
+const parseRequiredDoneRatio = (value: unknown): number => {
+    const parsed = typeof value === 'number' ? value : Number(value);
+    if (!Number.isFinite(parsed) || parsed < 0 || parsed > 100) {
+        throw new Error('Invalid response: done_ratio');
+    }
+    return parsed;
+};
+
 const parseStatus = (value: unknown): TaskStatus | null => {
     const record = asRecord(value);
     if (!record) return null;
@@ -688,18 +712,20 @@ export const apiClient = {
             task: {
                 id: String(taskIdValue),
                 subject: String(subjectValue),
-                assignedToId: typeof assignedToIdValue === 'number' ? assignedToIdValue : null,
-                statusId: typeof statusIdValue === 'number' ? statusIdValue : Number(statusIdValue || 0),
-                doneRatio: typeof doneRatioValue === 'number' ? doneRatioValue : Number(doneRatioValue || 0),
+                assignedToId: assignedToIdValue == null
+                    ? null
+                    : (Number.isFinite(Number(assignedToIdValue)) ? Number(assignedToIdValue) : null),
+                statusId: parseRequiredPositiveNumber(statusIdValue, 'status_id'),
+                doneRatio: parseRequiredDoneRatio(doneRatioValue),
                 dueDate: typeof dueDateValue === 'string' ? dueDateValue : null,
                 startDate: typeof startDateValue === 'string' ? startDateValue : null,
                 priorityId: typeof priorityIdValue === 'number' ? priorityIdValue : Number(priorityIdValue || 0),
                 categoryId: typeof categoryIdValue === 'number' ? categoryIdValue : (categoryIdValue ? Number(categoryIdValue) : null),
                 estimatedHours: typeof estimatedHoursValue === 'number' ? estimatedHoursValue : (estimatedHoursValue ? Number(estimatedHoursValue) : null),
-                projectId: typeof projectIdValue === 'number' ? projectIdValue : Number(projectIdValue || 0),
-                trackerId: typeof trackerIdValue === 'number' ? trackerIdValue : Number(trackerIdValue || 0),
+                projectId: parseRequiredPositiveNumber(projectIdValue, 'project_id'),
+                trackerId: parseRequiredPositiveNumber(trackerIdValue, 'tracker_id'),
                 fixedVersionId: typeof fixedVersionIdValue === 'number' ? fixedVersionIdValue : (fixedVersionIdValue ? Number(fixedVersionIdValue) : null),
-                lockVersion: typeof lockVersionValue === 'number' ? lockVersionValue : Number(lockVersionValue || 0)
+                lockVersion: parseRequiredNonNegativeNumber(lockVersionValue, 'lock_version')
             },
             editable: {
                 subject: editableSubject as boolean,

--- a/spa/src/api/editMeta.test.ts
+++ b/spa/src/api/editMeta.test.ts
@@ -134,14 +134,23 @@ describe('apiClient.fetchEditMeta', () => {
 
     it.each([
         [{ status_id: null }, 'status_id'],
+        [{ status_id: '' }, 'status_id'],
         [{ status_id: 0 }, 'status_id'],
+        [{ project_id: '' }, 'project_id'],
         [{ done_ratio: 101 }, 'done_ratio'],
         [{ done_ratio: -1 }, 'done_ratio'],
+        [{ done_ratio: null }, 'done_ratio'],
+        [{ done_ratio: '' }, 'done_ratio'],
+        [{ done_ratio: 1.5 }, 'done_ratio'],
         [{ project_id: null }, 'project_id'],
         [{ project_id: 0 }, 'project_id'],
         [{ tracker_id: null }, 'tracker_id'],
+        [{ tracker_id: '' }, 'tracker_id'],
         [{ tracker_id: 0 }, 'tracker_id'],
-        [{ lock_version: -1 }, 'lock_version']
+        [{ lock_version: null }, 'lock_version'],
+        [{ lock_version: '' }, 'lock_version'],
+        [{ lock_version: -1 }, 'lock_version'],
+        [{ lock_version: 1.5 }, 'lock_version']
     ])('throws when required field is invalid: %s', async (overrides, fieldName) => {
         window.RedmineCanvasGantt = {
             projectId: 1,
@@ -197,5 +206,40 @@ describe('apiClient.fetchEditMeta', () => {
 
         vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
         await expect(apiClient.fetchEditMeta('10')).rejects.toThrow(`Invalid response: ${fieldName}`);
+    });
+
+    it('accepts boundary done_ratio and lock_version values', async () => {
+        window.RedmineCanvasGantt = {
+            projectId: 1,
+            apiBase: '/projects/1/canvas_gantt',
+            redmineBase: '',
+            authToken: 'token',
+            apiKey: 'key'
+        };
+
+        const fetchMock = vi.fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    task: { id: 10, subject: 'S', assigned_to_id: null, status_id: 1, done_ratio: 0, due_date: null, lock_version: 0, project_id: 1, tracker_id: 2 },
+                    editable: { subject: true, assigned_to_id: true, status_id: true, done_ratio: true, due_date: true, start_date: true, priority_id: true, category_id: true, estimated_hours: true, project_id: true, tracker_id: true, fixed_version_id: true, custom_field_values: false },
+                    options: { statuses: [{ id: 1, name: 'New' }], assignees: [], priorities: [], categories: [], projects: [{ id: 1, name: 'Demo' }], trackers: [{ id: 2, name: 'Bug' }], versions: [], custom_fields: [] },
+                    custom_field_values: {}
+                })
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    task: { id: 10, subject: 'S', assigned_to_id: null, status_id: 1, done_ratio: 100, due_date: null, lock_version: 3, project_id: 1, tracker_id: 2 },
+                    editable: { subject: true, assigned_to_id: true, status_id: true, done_ratio: true, due_date: true, start_date: true, priority_id: true, category_id: true, estimated_hours: true, project_id: true, tracker_id: true, fixed_version_id: true, custom_field_values: false },
+                    options: { statuses: [{ id: 1, name: 'New' }], assignees: [], priorities: [], categories: [], projects: [{ id: 1, name: 'Demo' }], trackers: [{ id: 2, name: 'Bug' }], versions: [], custom_fields: [] },
+                    custom_field_values: {}
+                })
+            });
+
+        vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+
+        await expect(apiClient.fetchEditMeta('10')).resolves.toMatchObject({ task: { doneRatio: 0, lockVersion: 0 } });
+        await expect(apiClient.fetchEditMeta('10')).resolves.toMatchObject({ task: { doneRatio: 100, lockVersion: 3 } });
     });
 });

--- a/spa/src/api/editMeta.test.ts
+++ b/spa/src/api/editMeta.test.ts
@@ -59,11 +59,11 @@ describe('apiClient.fetchEditMeta', () => {
             dueDate: '2025-01-02',
             lockVersion: 3,
             startDate: null,
-            priorityId: NaN,
+            priorityId: 0,
             categoryId: null,
             estimatedHours: null,
-            projectId: NaN,
-            trackerId: NaN,
+            projectId: 0,
+            trackerId: 0,
             fixedVersionId: null
         });
         expect(meta.options.statuses).toEqual([{ id: 1, name: 'New' }]);

--- a/spa/src/api/editMeta.test.ts
+++ b/spa/src/api/editMeta.test.ts
@@ -21,7 +21,9 @@ describe('apiClient.fetchEditMeta', () => {
                     status_id: 1,
                     done_ratio: 10,
                     due_date: '2025-01-02',
-                    lock_version: 3
+                    lock_version: 3,
+                    project_id: 1,
+                    tracker_id: 2
                 },
                 editable: {
                     subject: true,
@@ -62,8 +64,8 @@ describe('apiClient.fetchEditMeta', () => {
             priorityId: 0,
             categoryId: null,
             estimatedHours: null,
-            projectId: 0,
-            trackerId: 0,
+            projectId: 1,
+            trackerId: 2,
             fixedVersionId: null
         });
         expect(meta.options.statuses).toEqual([{ id: 1, name: 'New' }]);
@@ -128,5 +130,72 @@ describe('apiClient.fetchEditMeta', () => {
 
         const meta = await apiClient.fetchEditMeta('10');
         expect(meta.options.priorities).toEqual([{ id: 7, name: '緊急', position: 4 }]);
+    });
+
+    it.each([
+        [{ status_id: null }, 'status_id'],
+        [{ status_id: 0 }, 'status_id'],
+        [{ done_ratio: 101 }, 'done_ratio'],
+        [{ done_ratio: -1 }, 'done_ratio'],
+        [{ project_id: null }, 'project_id'],
+        [{ project_id: 0 }, 'project_id'],
+        [{ tracker_id: null }, 'tracker_id'],
+        [{ tracker_id: 0 }, 'tracker_id'],
+        [{ lock_version: -1 }, 'lock_version']
+    ])('throws when required field is invalid: %s', async (overrides, fieldName) => {
+        window.RedmineCanvasGantt = {
+            projectId: 1,
+            apiBase: '/projects/1/canvas_gantt',
+            redmineBase: '',
+            authToken: 'token',
+            apiKey: 'key'
+        };
+
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                task: {
+                    id: 10,
+                    subject: 'S',
+                    assigned_to_id: null,
+                    status_id: 1,
+                    done_ratio: 10,
+                    due_date: null,
+                    lock_version: 3,
+                    project_id: 1,
+                    tracker_id: 2,
+                    ...overrides
+                },
+                editable: {
+                    subject: true,
+                    assigned_to_id: true,
+                    status_id: true,
+                    done_ratio: true,
+                    due_date: true,
+                    start_date: true,
+                    priority_id: true,
+                    category_id: true,
+                    estimated_hours: true,
+                    project_id: true,
+                    tracker_id: true,
+                    fixed_version_id: true,
+                    custom_field_values: false
+                },
+                options: {
+                    statuses: [{ id: 1, name: 'New' }],
+                    assignees: [],
+                    priorities: [],
+                    categories: [],
+                    projects: [{ id: 1, name: 'Demo' }],
+                    trackers: [{ id: 2, name: 'Bug' }],
+                    versions: [],
+                    custom_fields: []
+                },
+                custom_field_values: {}
+            })
+        });
+
+        vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+        await expect(apiClient.fetchEditMeta('10')).rejects.toThrow(`Invalid response: ${fieldName}`);
     });
 });

--- a/spa/src/components/BlurSave.test.tsx
+++ b/spa/src/components/BlurSave.test.tsx
@@ -73,7 +73,15 @@ describe('UiSidebar Blur-to-Save', () => {
                 return {
                     ok: true,
                     json: async () => ({
-                        task: { id: 123, subject: 'Initial Subject', status_id: 1, done_ratio: 0, lock_version: 1 },
+                        task: {
+                            id: 123,
+                            subject: 'Initial Subject',
+                            status_id: 1,
+                            done_ratio: 0,
+                            lock_version: 1,
+                            project_id: 1,
+                            tracker_id: 1
+                        },
                         editable: {
                             subject: true,
                             assigned_to_id: true,
@@ -94,7 +102,7 @@ describe('UiSidebar Blur-to-Save', () => {
                     })
                 } as unknown as Response;
             }
-            if (url.endsWith(`/tasks/${taskId}.json`) && init?.method === 'PATCH') {
+            if (url.includes(`/canvas_gantt/tasks/${taskId}.json`) && init?.method === 'PATCH') {
                 return {
                     ok: true,
                     json: async () => ({ lock_version: 2 })

--- a/spec/controllers/canvas_gantts_controller_spec.rb
+++ b/spec/controllers/canvas_gantts_controller_spec.rb
@@ -497,6 +497,63 @@ RSpec.describe CanvasGanttsController, type: :controller do
     end
   end
 
+  describe 'GET #edit_meta' do
+    let(:issue_scope) { double('IssueScope') }
+    let(:issue_project) do
+      instance_double(Project, id: 99, issue_categories: [], trackers: [])
+    end
+    let(:issue) do
+      instance_double(
+        Issue,
+        id: 42,
+        project_id: 99,
+        project: issue_project,
+        editable?: true,
+        safe_attribute?: true
+      )
+    end
+
+    before do
+      allow(controller).to receive(:set_permissions) do
+        controller.instance_variable_set(:@permissions, { editable: true, viewable: true, baseline_editable: false })
+      end
+      allow(Issue).to receive(:visible).and_return(issue_scope)
+      allow(issue_scope).to receive(:find).with('42').and_return(issue)
+      allow(controller).to receive(:current_view_scope).and_return({ issue_ids: Set[42], visible_project_ids: [1, 99] })
+      allow(issue).to receive(:new_statuses_allowed_to).and_return([])
+      allow(issue).to receive(:assignable_users).and_return([])
+      allow(issue).to receive(:subject).and_return('Scoped issue')
+      allow(issue).to receive(:assigned_to_id).and_return(nil)
+      allow(issue).to receive(:status_id).and_return(1)
+      allow(issue).to receive(:done_ratio).and_return(0)
+      allow(issue).to receive(:due_date).and_return(nil)
+      allow(issue).to receive(:start_date).and_return(nil)
+      allow(issue).to receive(:priority_id).and_return(nil)
+      allow(issue).to receive(:category_id).and_return(nil)
+      allow(issue).to receive(:estimated_hours).and_return(nil)
+      allow(issue).to receive(:tracker_id).and_return(nil)
+      allow(issue).to receive(:fixed_version_id).and_return(nil)
+      allow(issue).to receive(:lock_version).and_return(1)
+      allow(issue).to receive(:status).and_return(nil)
+      allow(IssuePriority).to receive(:active).and_return([])
+      allow(Project).to receive_message_chain(:allowed_to, :active, :where).and_return([])
+      allow(Version).to receive_message_chain(:visible, :where).and_return([])
+      allow(controller).to receive(:custom_field_extractor).and_return(
+        instance_double(
+          RedmineCanvasGantt::CustomFieldExtractor,
+          extract_custom_fields: [[], {}]
+        )
+      )
+    end
+
+    it 'allows edit_meta for a non-descendant issue when member-project mode view scope includes it' do
+      get :edit_meta, params: { project_id: 'demo', id: '42', member_projects_only: '1' }, format: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body).dig('task', 'id')).to eq(42)
+    end
+  end
+
   describe 'PATCH #update' do
     let(:issue_scope) { double('IssueScope') }
     let(:issue) do

--- a/spec/controllers/canvas_gantts_controller_spec.rb
+++ b/spec/controllers/canvas_gantts_controller_spec.rb
@@ -519,7 +519,7 @@ RSpec.describe CanvasGanttsController, type: :controller do
       end
       allow(Issue).to receive(:visible).and_return(issue_scope)
       allow(issue_scope).to receive(:find).with('42').and_return(issue)
-      allow(controller).to receive(:current_view_scope).and_return({ issue_ids: Set[42], visible_project_ids: [1, 99] })
+      allow(controller).to receive(:current_view_scope).and_return({ issue_ids: Set[42], scope_project_ids: [1, 99], visible_project_ids: [99] })
       allow(issue).to receive(:new_statuses_allowed_to).and_return([])
       allow(issue).to receive(:assignable_users).and_return([])
       allow(issue).to receive(:subject).and_return('Scoped issue')

--- a/spec/controllers/canvas_gantts_controller_spec.rb
+++ b/spec/controllers/canvas_gantts_controller_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../spec_helper'
+require 'set'
 
 RSpec.describe CanvasGanttsController, type: :controller do
   def canvas_gantt_t(key)
@@ -516,6 +517,7 @@ RSpec.describe CanvasGanttsController, type: :controller do
       allow(issue_scope).to receive(:find).with('10').and_return(issue)
       allow(controller).to receive(:ensure_issue_in_scope).and_return(true)
       allow(controller).to receive(:ensure_issue_editable).and_return(true)
+      allow(controller).to receive(:ensure_project_move_valid!).and_return(true)
     end
 
     it 'returns conflict on stale object error' do
@@ -711,20 +713,24 @@ RSpec.describe CanvasGanttsController, type: :controller do
 
   describe 'PATCH #update_relation' do
     let(:relation) { instance_double(IssueRelation, id: 77, issue_from_id: 10, issue_to_id: 11, save: true) }
-    let(:issue_from) { instance_double(Issue, project_id: 1, editable?: false) }
-    let(:issue_to) { instance_double(Issue, project_id: 2, editable?: true) }
+    let(:project_from) { instance_double(Project, id: 1) }
+    let(:project_to) { instance_double(Project, id: 2) }
+    let(:issue_from) { instance_double(Issue, id: 10, project_id: 1, project: project_from, editable?: true) }
+    let(:issue_to) { instance_double(Issue, id: 11, project_id: 2, project: project_to, editable?: true) }
 
     before do
       allow(controller).to receive(:set_permissions) do
         controller.instance_variable_set(:@permissions, { editable: true, viewable: true })
       end
-      allow(controller).to receive(:descendant_project_ids).and_return([1, 2])
-      allow(controller).to receive(:issue_scope).with([1, 2]).and_return(double(to_a: []))
+      allow(controller).to receive(:current_view_issue_ids).and_return(Set[10, 11])
+      allow(controller).to receive(:current_view_scope).and_return({ issues: [] })
       allow(IssueRelation).to receive(:find).with('77').and_return(relation)
       allow(relation).to receive(:issue_from).and_return(issue_from)
       allow(relation).to receive(:issue_to).and_return(issue_to)
       allow(relation).to receive(:errors).and_return(double(full_messages: ['Save failed']))
       allow(Setting).to receive(:non_working_week_days).and_return([0, 6])
+      allow(User.current).to receive(:allowed_to?).with(:edit_issues, project_from).and_return(true)
+      allow(User.current).to receive(:allowed_to?).with(:edit_issues, project_to).and_return(true)
 
       current_type = 'precedes'
       current_delay = 2
@@ -753,6 +759,7 @@ RSpec.describe CanvasGanttsController, type: :controller do
     end
 
     it 'returns forbidden when owned issue is not editable' do
+      allow(User.current).to receive(:allowed_to?).with(:edit_issues, project_from).and_return(false)
       patch :update_relation,
             params: { project_id: 'demo', id: '77', relation: { relation_type: 'blocks' } },
             format: :json
@@ -762,8 +769,8 @@ RSpec.describe CanvasGanttsController, type: :controller do
     end
 
     it 'returns not found when relation is outside the current project' do
-      allow(relation).to receive(:issue_from).and_return(instance_double(Issue, project_id: 3, editable?: true))
-      allow(relation).to receive(:issue_to).and_return(instance_double(Issue, project_id: 4, editable?: true))
+      allow(relation).to receive(:issue_from).and_return(instance_double(Issue, id: 30, project_id: 3, project: project_from, editable?: true))
+      allow(relation).to receive(:issue_to).and_return(instance_double(Issue, id: 40, project_id: 4, project: project_to, editable?: true))
 
       patch :update_relation,
             params: { project_id: 'demo', id: '77', relation: { relation_type: 'blocks' } },
@@ -834,7 +841,7 @@ RSpec.describe CanvasGanttsController, type: :controller do
     it 'rejects relation updates that would create a scheduling cycle' do
       allow(issue_from).to receive(:editable?).and_return(true)
       existing_relations = [{ id: '12', from: 11, to: 10, type: 'precedes', delay: 0 }]
-      allow(controller).to receive(:issue_scope).with([1, 2]).and_return(double(to_a: [double('Issue')]))
+      allow(controller).to receive(:current_view_scope).and_return({ issues: [double('Issue')] })
       allow(controller).to receive(:build_relations).and_return(existing_relations)
 
       patch :update_relation,
@@ -859,21 +866,23 @@ RSpec.describe CanvasGanttsController, type: :controller do
 
   describe 'POST #create_relation' do
     let(:issue_scope) { double('IssueScope') }
-    let(:issue_from) { instance_double(Issue, id: 10, project_id: 1, editable?: true, due_date: Date.new(2026, 1, 2), start_date: Date.new(2026, 1, 1)) }
-    let(:issue_to) { instance_double(Issue, id: 11, project_id: 1, editable?: true, due_date: Date.new(2026, 1, 5), start_date: Date.new(2026, 1, 4)) }
+    let(:issue_project) { instance_double(Project, id: 1) }
+    let(:issue_from) { instance_double(Issue, id: 10, project_id: 1, project: issue_project, editable?: true, due_date: Date.new(2026, 1, 2), start_date: Date.new(2026, 1, 1)) }
+    let(:issue_to) { instance_double(Issue, id: 11, project_id: 1, project: issue_project, editable?: true, due_date: Date.new(2026, 1, 5), start_date: Date.new(2026, 1, 4)) }
     let(:relation) { instance_double(IssueRelation, id: 88, issue_from_id: 10, issue_to_id: 11, relation_type: 'precedes', delay: 2, save: true) }
 
     before do
       allow(controller).to receive(:set_permissions) do
         controller.instance_variable_set(:@permissions, { editable: true, viewable: true })
       end
-      allow(controller).to receive(:descendant_project_ids).and_return([1])
-      allow(controller).to receive(:issue_scope).with([1]).and_return(double(to_a: []))
+      allow(controller).to receive(:current_view_issue_ids).and_return(Set[10, 11])
+      allow(controller).to receive(:current_view_scope).and_return({ issues: [] })
       allow(Issue).to receive(:visible).and_return(issue_scope)
       allow(issue_scope).to receive(:find).with('10').and_return(issue_from)
       allow(issue_scope).to receive(:find).with('11').and_return(issue_to)
       allow(IssueRelation).to receive(:new).and_return(relation)
       allow(Setting).to receive(:non_working_week_days).and_return([0, 6])
+      allow(User.current).to receive(:allowed_to?).with(:edit_issues, kind_of(Project)).and_return(true)
     end
 
     it 'creates a relation when delay matches current task dates' do
@@ -904,7 +913,7 @@ RSpec.describe CanvasGanttsController, type: :controller do
     end
 
     it 'rejects relation creation that would create a scheduling cycle' do
-      allow(controller).to receive(:issue_scope).with([1]).and_return(double(to_a: [double('Issue')]))
+      allow(controller).to receive(:current_view_scope).and_return({ issues: [double('Issue')] })
       allow(controller).to receive(:build_relations).and_return([
         { id: '12', from: 11, to: 10, type: 'precedes', delay: 0 }
       ])
@@ -930,22 +939,27 @@ RSpec.describe CanvasGanttsController, type: :controller do
 
   describe 'DELETE #destroy_relation' do
     let(:relation) { instance_double(IssueRelation) }
-    let(:issue_from) { instance_double(Issue, project_id: 1, editable?: false) }
-    let(:issue_to) { instance_double(Issue, project_id: 2, editable?: true) }
+    let(:project_from) { instance_double(Project, id: 1) }
+    let(:project_to) { instance_double(Project, id: 2) }
+    let(:issue_from) { instance_double(Issue, id: 10, project_id: 1, project: project_from, editable?: false) }
+    let(:issue_to) { instance_double(Issue, id: 11, project_id: 2, project: project_to, editable?: true) }
 
     before do
       allow(controller).to receive(:set_permissions) do
         controller.instance_variable_set(:@permissions, { editable: true, viewable: true })
       end
-      allow(controller).to receive(:descendant_project_ids).and_return([1, 2])
+      allow(controller).to receive(:current_view_issue_ids).and_return(Set[10, 11])
       allow(IssueRelation).to receive(:find).with('77').and_return(relation)
       allow(relation).to receive(:issue_from).and_return(issue_from)
       allow(relation).to receive(:issue_to).and_return(issue_to)
+      allow(User.current).to receive(:allowed_to?).with(:edit_issues, project_from).and_return(false)
+      allow(User.current).to receive(:allowed_to?).with(:edit_issues, project_to).and_return(true)
     end
 
     it 'destroys a relation when either side belongs to a descendant project' do
-      allow(relation).to receive(:issue_from).and_return(instance_double(Issue, project_id: 2, editable?: true))
-      allow(relation).to receive(:issue_to).and_return(instance_double(Issue, project_id: 3, editable?: true))
+      allow(relation).to receive(:issue_from).and_return(instance_double(Issue, id: 10, project_id: 2, project: project_from, editable?: true))
+      allow(relation).to receive(:issue_to).and_return(instance_double(Issue, id: 11, project_id: 3, project: project_to, editable?: true))
+      allow(User.current).to receive(:allowed_to?).with(:edit_issues, project_from).and_return(true)
       allow(relation).to receive(:destroy)
 
       delete :destroy_relation, params: { project_id: 'demo', id: '77' }, format: :json
@@ -963,8 +977,8 @@ RSpec.describe CanvasGanttsController, type: :controller do
     end
 
     it 'returns not found when relation is outside the current project' do
-      allow(relation).to receive(:issue_from).and_return(instance_double(Issue, project_id: 3, editable?: true))
-      allow(relation).to receive(:issue_to).and_return(instance_double(Issue, project_id: 4, editable?: true))
+      allow(relation).to receive(:issue_from).and_return(instance_double(Issue, id: 30, project_id: 3, project: project_from, editable?: true))
+      allow(relation).to receive(:issue_to).and_return(instance_double(Issue, id: 40, project_id: 4, project: project_to, editable?: true))
 
       delete :destroy_relation, params: { project_id: 'demo', id: '77' }, format: :json
 

--- a/spec/controllers/canvas_gantts_controller_spec.rb
+++ b/spec/controllers/canvas_gantts_controller_spec.rb
@@ -1080,6 +1080,49 @@ RSpec.describe CanvasGanttsController, type: :controller do
     end
   end
 
+  describe '#ensure_project_move_valid!' do
+    let(:destination_project) { instance_double(Project, id: 3) }
+    let(:tracker) { instance_double(Tracker) }
+    let(:issue_errors) { instance_double(ActiveModel::Errors, add: nil, full_messages: ['invalid']) }
+    let(:issue) do
+      instance_double(
+        Issue,
+        project: destination_project,
+        tracker: tracker,
+        assigned_to_id: nil,
+        assignable_users: [],
+        fixed_version: nil,
+        category: nil,
+        errors: issue_errors
+      )
+    end
+
+    before do
+      allow(controller).to receive(:permitted_task_params).and_return(ActionController::Parameters.new(project_id: '3'))
+      allow(destination_project).to receive(:trackers).and_return([tracker])
+      allow(User.current).to receive(:allowed_to?).with(:add_issues, destination_project).and_return(true)
+    end
+
+    it 'allows move to a project in scope_project_ids even if not in visible_project_ids' do
+      allow(controller).to receive(:current_view_scope).and_return(
+        scope_project_ids: [3, 5],
+        visible_project_ids: [5]
+      )
+
+      expect(controller.send(:ensure_project_move_valid!, issue)).to be(true)
+    end
+
+    it 'forbids move to a project outside scope_project_ids' do
+      allow(controller).to receive(:current_view_scope).and_return(
+        scope_project_ids: [5],
+        visible_project_ids: [5]
+      )
+
+      expect(controller.send(:ensure_project_move_valid!, issue)).to be(false)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
   describe 'CustomFieldExtractor helpers' do
     let(:allowed_custom_field) do
       instance_double(

--- a/spec/lib/redmine_canvas_gantt/data_payload_builder_spec.rb
+++ b/spec/lib/redmine_canvas_gantt/data_payload_builder_spec.rb
@@ -43,4 +43,22 @@ RSpec.describe RedmineCanvasGantt::DataPayloadBuilder do
       )
     end
   end
+
+  describe '#build_relations' do
+    it 'returns only relations where both endpoints are visible' do
+      builder = described_class.new(
+        custom_field_extractor: instance_double(RedmineCanvasGantt::CustomFieldExtractor),
+        current_user: instance_double(User)
+      )
+
+      visible_relation = instance_double(IssueRelation, issue_from_id: 1, issue_to_id: 2, id: 10, relation_type: 'precedes', delay: 0)
+      hidden_relation = instance_double(IssueRelation, issue_from_id: 1, issue_to_id: 99, id: 11, relation_type: 'precedes', delay: 1)
+      issue_a = instance_double(Issue, id: 1, relations: [visible_relation, hidden_relation])
+      issue_b = instance_double(Issue, id: 2, relations: [visible_relation])
+
+      expect(builder.build_relations([issue_a, issue_b])).to eq([
+        { id: 10, from: 1, to: 2, type: 'precedes', delay: 0 }
+      ])
+    end
+  end
 end

--- a/spec/lib/redmine_canvas_gantt/data_payload_builder_spec.rb
+++ b/spec/lib/redmine_canvas_gantt/data_payload_builder_spec.rb
@@ -1,6 +1,11 @@
 require_relative '../../spec_helper'
 
 RSpec.describe RedmineCanvasGantt::DataPayloadBuilder do
+  it 'requires set explicitly for to_set usage' do
+    source = File.read(File.expand_path('../../../lib/redmine_canvas_gantt/data_payload_builder.rb', __dir__))
+    expect(source).to include("require 'set'")
+  end
+
   describe '#build' do
     it 'builds stable filter options for descendant projects and assignees' do
       custom_field_extractor = instance_double(

--- a/spec/lib/redmine_canvas_gantt/edit_meta_payload_builder_spec.rb
+++ b/spec/lib/redmine_canvas_gantt/edit_meta_payload_builder_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe RedmineCanvasGantt::EditMetaPayloadBuilder do
         status_id: 12,
         done_ratio: 34,
         due_date: Date.new(2026, 1, 1),
+        start_date: Date.new(2025, 12, 1),
+        priority_id: 3,
+        category_id: 4,
+        estimated_hours: 12.5,
+        tracker_id: 5,
+        fixed_version_id: 6,
         lock_version: 9,
         status: current_status,
         project: project,
@@ -33,7 +39,7 @@ RSpec.describe RedmineCanvasGantt::EditMetaPayloadBuilder do
       allow(issue).to receive(:assignable_users).and_return([assignable_user])
 
       allow(IssuePriority).to receive(:active).and_return([priority])
-      project_scope = double(active: [visible_project])
+      project_scope = double(active: double(where: [visible_project]))
       allow(Project).to receive(:allowed_to).with(:add_issues).and_return(project_scope)
       version_scope = double(where: [instance_double(Version, id: 6, name: 'v1')])
       allow(Version).to receive(:visible).and_return(version_scope)
@@ -43,7 +49,8 @@ RSpec.describe RedmineCanvasGantt::EditMetaPayloadBuilder do
         editable: { subject: true },
         custom_fields: [{ id: 99 }],
         custom_field_values: { '99' => 'abc' },
-        permissions: { editable: true, viewable: true }
+        permissions: { editable: true, viewable: true },
+        visible_project_ids: [20]
       )
 
       expect(payload).to include(
@@ -51,7 +58,19 @@ RSpec.describe RedmineCanvasGantt::EditMetaPayloadBuilder do
         custom_field_values: { '99' => 'abc' },
         permissions: { editable: true, viewable: true }
       )
-      expect(payload[:task]).to include(id: 10, subject: 'Fix bug', status_id: 12, lock_version: 9)
+      expect(payload[:task]).to include(
+        id: 10,
+        subject: 'Fix bug',
+        status_id: 12,
+        start_date: Date.new(2025, 12, 1),
+        priority_id: 3,
+        category_id: 4,
+        estimated_hours: 12.5,
+        project_id: 1,
+        tracker_id: 5,
+        fixed_version_id: 6,
+        lock_version: 9
+      )
       expect(payload[:options][:statuses]).to eq([{ id: 1, name: 'Open' }, { id: 2, name: 'In Progress' }])
       expect(payload[:options][:assignees]).to eq([{ id: 7, name: 'Alice' }])
       expect(payload[:options][:custom_fields]).to eq([{ id: 99 }])

--- a/spec/lib/redmine_canvas_gantt/edit_meta_payload_builder_spec.rb
+++ b/spec/lib/redmine_canvas_gantt/edit_meta_payload_builder_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe RedmineCanvasGantt::EditMetaPayloadBuilder do
         custom_fields: [{ id: 99 }],
         custom_field_values: { '99' => 'abc' },
         permissions: { editable: true, viewable: true },
-        visible_project_ids: [20]
+        project_scope_ids: [20]
       )
 
       expect(payload).to include(

--- a/spec/lib/redmine_canvas_gantt/view_scope_resolver_spec.rb
+++ b/spec/lib/redmine_canvas_gantt/view_scope_resolver_spec.rb
@@ -1,0 +1,70 @@
+require_relative '../../spec_helper'
+require_relative '../../../lib/redmine_canvas_gantt/view_scope_resolver'
+
+RSpec.describe RedmineCanvasGantt::ViewScopeResolver do
+  let(:project_relation) { instance_double(ActiveRecord::Relation, pluck: [1, 2]) }
+  let(:project) { instance_double(Project, self_and_descendants: project_relation) }
+  let(:current_user) { instance_double(User) }
+  let(:query_state_resolver) { instance_double(RedmineCanvasGantt::QueryStateResolver) }
+  let(:issue_a) { instance_double(Issue, id: 10, project_id: 1) }
+  let(:issue_b) { instance_double(Issue, id: 20, project_id: 5) }
+
+  before do
+    allow(RedmineCanvasGantt::QueryStateResolver).to receive(:new).and_return(query_state_resolver)
+  end
+
+  it 'uses descendant project ids when member-project mode is off' do
+    allow(query_state_resolver).to receive(:resolve).with(project_ids: [1, 2]).and_return(
+      issues: [issue_a],
+      initial_state: {},
+      warnings: []
+    )
+
+    result = described_class.new(
+      project: project,
+      params: ActionController::Parameters.new(member_projects_only: '0'),
+      current_user: current_user,
+      issue_includes: []
+    ).resolve
+
+    expect(result[:issue_ids]).to eq(Set[10])
+  end
+
+  it 'uses member project ids when member-project mode is on without explicit project_ids' do
+    allow(query_state_resolver).to receive(:resolve).with(project_ids: [5, 6]).and_return(
+      issues: [issue_b],
+      initial_state: {},
+      warnings: []
+    )
+
+    result = described_class.new(
+      project: project,
+      params: ActionController::Parameters.new(member_projects_only: '1'),
+      current_user: current_user,
+      issue_includes: [],
+      member_project_ids_resolver: -> { [5, 6] }
+    ).resolve
+
+    expect(result[:issue_ids]).to eq(Set[20])
+    expect(result[:visible_project_ids]).to eq([5])
+  end
+
+  it 'still lets explicit project_ids narrow scope through QueryStateResolver' do
+    params = ActionController::Parameters.new(member_projects_only: '1', project_ids: ['6'])
+    allow(query_state_resolver).to receive(:resolve).with(project_ids: [5, 6]).and_return(
+      issues: [issue_b],
+      initial_state: { selected_project_ids: ['6'] },
+      warnings: []
+    )
+
+    result = described_class.new(
+      project: project,
+      params: params,
+      current_user: current_user,
+      issue_includes: [],
+      member_project_ids_resolver: -> { [5, 6] }
+    ).resolve
+
+    expect(result[:initial_state][:selected_project_ids]).to eq(['6'])
+  end
+end

--- a/spec/lib/redmine_canvas_gantt/view_scope_resolver_spec.rb
+++ b/spec/lib/redmine_canvas_gantt/view_scope_resolver_spec.rb
@@ -71,4 +71,23 @@ RSpec.describe RedmineCanvasGantt::ViewScopeResolver do
     expect(result[:initial_state][:selected_project_ids]).to eq(['6'])
     expect(result[:scope_project_ids]).to eq([6])
   end
+
+  it 'excludes explicit project_ids outside base_project_ids' do
+    params = ActionController::Parameters.new(member_projects_only: '1', project_ids: %w[6 999])
+    allow(query_state_resolver).to receive(:resolve).with(project_ids: [6]).and_return(
+      issues: [issue_b],
+      initial_state: {},
+      warnings: []
+    )
+
+    result = described_class.new(
+      project: project,
+      params: params,
+      current_user: current_user,
+      issue_includes: [],
+      member_project_ids_resolver: -> { [5, 6] }
+    ).resolve
+
+    expect(result[:scope_project_ids]).to eq([6])
+  end
 end

--- a/spec/lib/redmine_canvas_gantt/view_scope_resolver_spec.rb
+++ b/spec/lib/redmine_canvas_gantt/view_scope_resolver_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe RedmineCanvasGantt::ViewScopeResolver do
     ).resolve
 
     expect(result[:issue_ids]).to eq(Set[10])
+    expect(result[:scope_project_ids]).to eq([1, 2])
+    expect(result[:visible_project_ids]).to eq([1])
   end
 
   it 'uses member project ids when member-project mode is on without explicit project_ids' do
@@ -46,12 +48,13 @@ RSpec.describe RedmineCanvasGantt::ViewScopeResolver do
     ).resolve
 
     expect(result[:issue_ids]).to eq(Set[20])
+    expect(result[:scope_project_ids]).to eq([5, 6])
     expect(result[:visible_project_ids]).to eq([5])
   end
 
   it 'still lets explicit project_ids narrow scope through QueryStateResolver' do
     params = ActionController::Parameters.new(member_projects_only: '1', project_ids: ['6'])
-    allow(query_state_resolver).to receive(:resolve).with(project_ids: [5, 6]).and_return(
+    allow(query_state_resolver).to receive(:resolve).with(project_ids: [6]).and_return(
       issues: [issue_b],
       initial_state: { selected_project_ids: ['6'] },
       warnings: []
@@ -66,5 +69,6 @@ RSpec.describe RedmineCanvasGantt::ViewScopeResolver do
     ).resolve
 
     expect(result[:initial_state][:selected_project_ids]).to eq(['6'])
+    expect(result[:scope_project_ids]).to eq([6])
   end
 end


### PR DESCRIPTION
### Motivation
- Align update behavior with the visible Gantt view so display scope and update scope match for tasks, relations and bulk actions.
- Prevent edits/relations/bulk subtasks when target issues are filtered out of the current view and use issue/project entity permission checks.
- Provide global update endpoints so the server can re-evaluate the current view scope for mutating requests.

### Description
- Added global non-project-scoped routes for edit/update/relations/subtasks (`/canvas_gantt/*`) while retaining existing project-scoped routes for compatibility in `config/routes.rb`.
- Introduced `RedmineCanvasGantt::ViewScopeResolver` to reconstruct the current visible issue set from request context and reused it in controller checks.
- Updated `CanvasGanttsController` to: use `resolve_canvas_project` for global vs project routes; enforce issue-level in-view checks (`ensure_issue_in_scope`); switch to entity-based permission checks (`issue_editable?`); require both endpoints to be in-view and editable for relation create/update/delete; validate project moves against visible project scope and required permissions and clear invalid version/category or return validation errors for invalid tracker/assignee.
- Expanded `EditMetaPayloadBuilder` task payload to include the frontend-required fields and limited project move `projects` options to visible, allowed projects.
- Made `DataPayloadBuilder#build_relations` filter out relations whose endpoints are not both present in the current visible task set.
- SPA client (`spa/src/api/client.ts`) now uses global endpoints (`/canvas_gantt/*`) and attaches view-context via query params (`canvas_project_id` + current URL query state); parsing hardened to avoid `NaN` and handle missing/null safely.
- Updated tests: SPA unit tests adjusted for new endpoint URLs and hardened `edit_meta` parsing; backend unit/spec tests updated to assert relation filtering, edit_meta contract and controller view-scope logic.

### Testing
- Frontend unit tests: `cd spa && npm run test -- --run src/api/client.test.ts src/api/editMeta.test.ts` — 2 test files, 11 tests passed (Vitest) ✅.
- Ruby syntax checks: `ruby -c` on modified Ruby files (`app/controllers/canvas_gantts_controller.rb`, `lib/redmine_canvas_gantt/*.rb`) — syntax OK ✅.
- Backend RSpec could not be executed in this environment because the plugin's tests must run from the Redmine runtime (no Gemfile here) and `docker` is not available here; updated controller/spec files but full RSpec run is pending in CI or a Redmine runtime. ⚠️
