### PR TITLE
docs: update README for current Canvas Gantt features

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,19 @@
 
 # Redmine Canvas Gantt
 
-High-performance Canvas-based Gantt chart plugin for Redmine.
+High-performance Canvas-based Gantt chart plugin for Redmine 6.x.
 
 Listed on Redmine Plugins Directory:
 https://www.redmine.org/plugins/redmine_canvas_gantt
 
 [![License](https://img.shields.io/github/license/tiohsa/redmine_canvas_gantt)](LICENSE)
+[![CI](https://img.shields.io/github/actions/workflow/status/tiohsa/redmine_canvas_gantt/ci.yml?branch=main&label=CI)](https://github.com/tiohsa/redmine_canvas_gantt/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/tiohsa/redmine_canvas_gantt)](https://github.com/tiohsa/redmine_canvas_gantt/releases)
 [![Redmine](https://img.shields.io/badge/Redmine-6.x-red)](#requirements)
 [![Ruby](https://img.shields.io/badge/Ruby-3.x-cc342d)](#requirements)
 [![Node.js](https://img.shields.io/badge/Node.js-20%2B-339933)](#requirements)
 
-[日本語 README](README_ja.md) · [Issues](https://github.com/tiohsa/redmine_canvas_gantt/issues)
+[日本語 README](README_ja.md) · [Releases](https://github.com/tiohsa/redmine_canvas_gantt/releases) · [Issues](https://github.com/tiohsa/redmine_canvas_gantt/issues)
 
 </div>
 
@@ -20,19 +22,66 @@ https://www.redmine.org/plugins/redmine_canvas_gantt
 
 ## Overview
 
-Redmine Canvas Gantt provides a fast, interactive Gantt chart for Redmine by rendering the timeline on HTML5 Canvas while keeping the left sidebar editable. It is intended for projects where the default Redmine Gantt becomes hard to read or slow to operate.
+Redmine Canvas Gantt is a Redmine plugin that provides a fast, interactive Gantt chart rendered with HTML5 Canvas. It keeps the left sidebar editable while using Canvas for the timeline, making large schedules easier to browse, edit, and explain than Redmine's default Gantt view.
+
+The plugin is designed for project managers and development teams that need a practical schedule view with inline editing, dependencies, baselines, Redmine query integration, and shareable project views without changing Redmine's database schema.
+
+## Current Version
+
+- Plugin version: `0.8.4`
+- Target Redmine version: Redmine 6.x
+- Database migration: none
+- Project module: `Canvas Gantt`
+- Permissions: `view_canvas_gantt`, `edit_canvas_gantt`
 
 ## Features
 
-- High-performance timeline rendering with smooth scrolling and zooming
-- Drag to move tasks, resize date ranges, and create dependencies from task endpoints
-- Dependency management with create, update, and remove operations
+### Gantt and schedule operation
+
+- High-performance Canvas timeline rendering
+- Smooth horizontal and vertical scrolling
+- Zoom controls and Ctrl/Cmd + mouse wheel zoom
+- Drag tasks to move date ranges
+- Drag task edges to resize start and due dates
+- Version headers, progress line, hierarchy lines, task titles, and row height presets
+- Device-pixel-ratio-aware Canvas rendering for sharper text on high-DPI displays
+
+### Dependency management
+
+- Create dependencies by dragging from task endpoint dots
+- Update dependency type and delay from the dependency editing UI
+- Remove existing dependencies
+- Organize visible issues by dependency structure when enabled
+
+### Issue editing
+
 - Inline quick edit for subject, assignee, status, progress, due date, and custom fields
-- Drag and drop to change parent-child relationships in the sidebar
+- Drag and drop sidebar rows to change parent-child relationships
 - Bulk subtask creation from multiple subject lines
-- Baseline snapshots for visual comparison, with filtered-view or whole-project save scope
-- Filters and grouping by project, assignee, status, version, and subject text
-- Version headers, progress line, row height presets, and persistent UI preferences
+- Configurable inline edit toggles from the plugin settings screen
+
+### Filters, queries, and shared views
+
+- Filter by project, assignee, status, version, and subject text
+- Group by project or assignee
+- Consume Redmine saved issue queries through `query_id`
+- Synchronize visible columns and sorting from Redmine saved queries
+- Support a subset of Redmine issue-list URL parameters
+- Restore last-used project-scoped shared filter state when opening a bare Canvas Gantt URL
+- Show toolbar indicators when saved queries or filters are active
+
+### Display preferences
+
+- Store personal UI preferences such as zoom, viewport, and sidebar width in `localStorage`
+- Share display settings across projects from the display settings menu
+- Shared display settings include zoom level, view mode, chart position, progress line, task titles, hierarchy lines, orphan-point display, version headers, baseline visibility, visible columns, column order, dependency organization, column widths, sidebar width, custom zoom scales, row height, and sidebar font size
+
+### Baseline snapshots
+
+- Save a baseline from the current filtered view or from the whole project
+- Compare current schedule bars against the saved baseline
+- Display baseline differences through bars and popovers
+- Keep baseline as a visual comparison feature only; it is not used as scheduling input
 
 ## Demo
 
@@ -47,11 +96,14 @@ Redmine Canvas Gantt provides a fast, interactive Gantt chart for Redmine by ren
 - Node.js 20+ for SPA build and frontend development
 - REST API enabled in Redmine
 
-### Security and impact
+## Security and Impact
 
-- Database migration: none
-- Added permissions: `view_canvas_gantt`, `edit_canvas_gantt`
-- Uninstall: remove the plugin directory and restart Redmine
+- No database migration is added by this plugin
+- Added permissions:
+  - `view_canvas_gantt`
+  - `edit_canvas_gantt`
+- Uninstall is performed by removing the plugin directory and restarting Redmine
+- The frontend build is served from Redmine plugin assets
 
 ## Installation
 
@@ -62,9 +114,17 @@ Redmine Canvas Gantt provides a fast, interactive Gantt chart for Redmine by ren
    git clone https://github.com/tiohsa/redmine_canvas_gantt.git
    ```
 
-2. Restart Redmine.
+2. Build the SPA frontend if the release package does not already include `assets/build/`.
 
-   Restart your application server after placing the plugin.
+   ```bash
+   cd redmine_canvas_gantt/spa
+   npm ci
+   npm run build
+   ```
+
+3. Restart Redmine.
+
+   Restart your application server after placing or updating the plugin.
 
 ## Usage
 
@@ -89,80 +149,80 @@ Redmine Canvas Gantt provides a fast, interactive Gantt chart for Redmine by ren
    - Drag a sidebar row onto another task to make it a child issue.
    - Use bulk subtask creation to add multiple child issues at once.
 
-### Baseline snapshots
+## Baseline Snapshots
+
+Baseline snapshots provide a simple way to compare the current schedule against a saved reference point.
 
 - Baseline is a comparison-only feature. It is not used as input for scheduling or CPM calculations.
 - Each project stores a single baseline snapshot, and saving a new one replaces the previous snapshot.
 - The toolbar lets you save either the current filtered view or the whole project as the baseline scope.
 - Baseline bars and diff popovers only render for tasks currently visible in the chart, even when the saved scope was the whole project.
-- Viewing baseline comparison requires `view_canvas_gantt`. Saving a baseline requires `edit_canvas_gantt`.
+- Viewing baseline comparison requires `view_canvas_gantt`.
+- Saving a baseline requires `edit_canvas_gantt`.
 
 ## Shared Views and Query Parameters
 
 Canvas Gantt separates shared business conditions from personal UI preferences.
 
-- Shared business conditions are resolved from the URL and optional `query_id`
-- Personal UI state such as zoom, viewport, sidebar width, and visible columns stays in `localStorage`
-- When the Canvas Gantt tab opens a bare `/canvas_gantt` URL, shared query conditions fall back to the last-used state stored in `localStorage` for that project
+- Shared business conditions are resolved from the URL and optional `query_id`.
+- Personal UI state such as zoom, viewport, and sidebar width stays in `localStorage`.
+- Display columns and sorting are treated as shared state that synchronizes with Redmine's standard queries.
+- Project-specific query and filter state such as `query_id`, project selection, status, assignee, version, or custom field conditions is not shared as a global display preference.
+- When the Canvas Gantt tab opens a bare `/canvas_gantt` URL, shared query conditions fall back to the last-used state stored in `localStorage` for that project.
 - When the same shared condition is provided by multiple sources, the precedence is:
-  URL parameters -> saved query (`query_id`) -> project-scoped last-used shared state -> defaults
+
+```text
+URL parameters -> saved query (`query_id`) -> project-scoped last-used shared state -> defaults
+```
 
 ### Query editing flow
 
 Canvas Gantt does not reimplement Redmine's query editor. Query creation, editing, and saving are done in the standard Redmine issue list, and Canvas Gantt consumes both saved queries and the supported subset of Redmine issue-list URL parameters.
 
-- Use **Edit Query in Redmine** in the Canvas Gantt toolbar to open the standard issue list for the current project
-- Adjust filters in the Redmine issue list and save the query with Redmine's built-in **Save** action
-- Use **Open in Canvas Gantt** in the issue list to return to Canvas Gantt with the current issue-list URL state
-- When the issue list is showing a saved query, the return link includes `query_id`
-- When the issue list is showing an unsaved standard filter, the return link carries the supported Redmine-standard filter parameters directly
+- Use the **Saved Queries** menu in the Canvas Gantt toolbar to browse saved Redmine queries that are visible in the current project.
+- Select a saved query to apply its `query_id` and reload Canvas Gantt from Redmine's saved query definition.
+- Use **Clear saved query** to remove `query_id` while keeping the currently resolved shared filters in the URL.
+- Use **Save custom query** to open the standard Redmine issue list inside an iframe dialog and save the current filter set without leaving Canvas Gantt.
+- Use **Edit Query in Redmine** from the same menu to open the standard issue list in the current tab.
+- Adjust filters in the Redmine issue list and save the query with Redmine's built-in **Save** action.
+- Use **Open in Canvas Gantt** in the issue list to return to Canvas Gantt with the current issue-list URL state.
+- When the issue list is showing a saved query, the return link includes `query_id`.
+- When the issue list is showing an unsaved standard filter, the return link carries the supported Redmine-standard filter parameters directly.
 
-`query_id` alone is enough only when the current view exactly matches the saved query. If Canvas Gantt adds extra shared filters on top of that saved query, the toolbar sends `query_id` plus standard Redmine filter parameters so the issue list can reproduce the same view as closely as possible.
+The saved-query editor dialog also exposes **Open in new tab** as a fallback when the embedded Redmine page is not convenient to use.
 
-When the project menu opens a bare `Canvas Gantt` URL with no shared query input, Canvas Gantt restores the last-used shared filter state for that project and rewrites the browser URL to the canonical shared query params.
+`query_id` alone is enough only when the current view exactly matches the saved query. Display columns and sorting are also restored based on the saved query definition. If Canvas Gantt adds extra shared filters, visible columns, or sorting on top of that saved query, the toolbar sends `query_id` plus standard Redmine parameters so the issue list can reproduce the same view as closely as possible.
+
+When the project menu opens a bare `Canvas Gantt` URL with no shared query input, Canvas Gantt restores the last-used shared filter state for that project and rewrites the browser URL to the canonical shared query parameters.
 
 ### Supported shared parameters
 
-- `query_id`: use an existing Redmine saved issue query as the base condition. Only persisted query ids are supported
-- `status_ids[]`: filter by issue status ids
-- `assigned_to_ids[]`: filter by assignee ids, use `none` for unassigned issues
-- `project_ids[]`: narrow the visible projects inside the current project/subproject scope
-- `fixed_version_ids[]`: filter by target version ids, use `none` for issues without a version
-- `group_by`: `project` or `assigned_to`
-- `sort`: frontend sort key plus direction, for example `subject:asc` or `startDate:desc`
-- `show_subprojects`: `0` to hide subprojects, omit it or use `1` to include them
+| Parameter | Description |
+| :--- | :--- |
+| `query_id` | Use an existing Redmine saved issue query as the base condition |
+| `status_ids[]` | Filter by issue status IDs |
+| `assigned_to_ids[]` | Filter by assignee IDs. Use `none` for unassigned issues |
+| `project_ids[]` | Narrow the visible projects inside the current project/subproject scope |
+| `fixed_version_ids[]` | Filter by target version IDs. Use `none` for issues without a version |
+| `group_by` | Grouping criteria. `project` or `assigned_to` |
+| `sort` | Frontend sort key plus direction. Example: `subject:asc`, `startDate:desc` |
+| `c[]` | Specify visible columns compatible with Redmine's `c[]`. Example: `c[]=subject&c[]=status` |
+| `show_subprojects` | Subproject visibility. `0` to hide, omit or `1` to include |
 
-Canvas Gantt also reads the following Redmine-standard issue list parameters:
+### Compatibility with Redmine issue list
 
-- `set_filter=1`
-- `f[]`
-- `op[field]`
-- `v[field][]`
-- `group_by`
-- `sort`
-
-Supported Redmine-standard fields:
-
-- `status_id`
-- `assigned_to_id`
-- `project_id`
-- `fixed_version_id`
-- `subproject_id`
-
-Supported Redmine-standard operators:
-
-- `=`
-- `*`
-- `!*`
-- `o`
-- `c`
+| Category | Supported Items |
+| :--- | :--- |
+| **Parameters** | `set_filter=1`, `f[]`, `op[field]`, `v[field][]`, `c[]`, `group_by`, `sort` |
+| **Fields** | `status_id`, `assigned_to_id`, `project_id`, `fixed_version_id`, `subproject_id` |
+| **Operators** | `=` equal, `*` all, `!*` none, `o` open, `c` closed |
 
 Current compatibility limits:
 
-- Unsupported Redmine fields or operators are ignored and shown as warnings
-- `assigned_to_id` with both specific assignees and unassigned issues cannot be represented exactly when exporting back to the Redmine issue list, so the unassigned part is omitted with a warning
-- Issues without a target version are supported in Canvas-specific URLs via `fixed_version_ids[]=none`, but that case is omitted when exporting a Redmine-standard issue-list URL
-- Default sort (`startDate:asc`) may be omitted when exporting a Redmine issue-list URL
+- Unsupported Redmine fields or operators are ignored and shown as warnings.
+- `assigned_to_id` with both specific assignees and unassigned issues cannot be represented exactly when exporting back to the Redmine issue list, so the unassigned part is omitted with a warning.
+- Issues without a target version are supported in Canvas-specific URLs via `fixed_version_ids[]=none`, but that case is omitted when exporting a Redmine-standard issue-list URL.
+- Default sort, such as `startDate:asc`, may be omitted when exporting a Redmine issue-list URL.
 
 ### Example URLs
 
@@ -200,9 +260,16 @@ Hide subprojects and show only unassigned issues:
 
 Configure the plugin from **Administration** -> **Plugins** -> **Canvas Gantt** -> **Configure**.
 
-- Inline edit toggles: `subject`, `assigned_to`, `status`, `done_ratio`, `due_date`, `custom_fields`
-- `row_height`: default row height
-- `use_vite_dev_server`: load frontend assets from `http://localhost:5173` during development
+| Setting | Description |
+| :--- | :--- |
+| `inline_edit_subject` | Enable subject inline editing |
+| `inline_edit_assigned_to` | Enable assignee inline editing |
+| `inline_edit_status` | Enable status inline editing |
+| `inline_edit_done_ratio` | Enable progress inline editing |
+| `inline_edit_due_date` | Enable due date inline editing |
+| `inline_edit_custom_fields` | Enable custom field inline editing |
+| `row_height` | Default row height |
+| `use_vite_dev_server` | Load frontend assets from `http://localhost:5173` during development |
 
 ### Compatibility note
 
@@ -271,9 +338,20 @@ npx playwright test -c playwright.redmine.config.ts
 
 ## Build Output
 
-- `npm run build` outputs the SPA to `assets/build/`
-- On Redmine boot, the plugin links or copies those files into `public/plugin_assets/redmine_canvas_gantt/build`
-- The fallback asset route is also available through `/plugin_assets/redmine_canvas_gantt/build/*`
+- `npm run build` outputs the SPA to `assets/build/`.
+- On Redmine boot, the plugin links or copies those files into `public/plugin_assets/redmine_canvas_gantt/build`.
+- The fallback asset route is also available through `/plugin_assets/redmine_canvas_gantt/build/*`.
+
+## Release
+
+GitHub Releases are created automatically when a tag matching `v*` is pushed.
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+The release workflow only creates the GitHub Release with generated notes. It does not build the SPA or package extension artifacts.
 
 ## License
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -2,17 +2,19 @@
 
 # Redmine Canvas Gantt
 
-Redmine 向けの高性能 Canvas ガントチャートプラグイン。
+Redmine 向けの高性能 Canvas ベース ガントチャートプラグイン。
 
 Listed on Redmine Plugins Directory:
 https://www.redmine.org/plugins/redmine_canvas_gantt
 
 [![License](https://img.shields.io/github/license/tiohsa/redmine_canvas_gantt)](LICENSE)
+[![CI](https://img.shields.io/github/actions/workflow/status/tiohsa/redmine_canvas_gantt/ci.yml?branch=main&label=CI)](https://github.com/tiohsa/redmine_canvas_gantt/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/tiohsa/redmine_canvas_gantt)](https://github.com/tiohsa/redmine_canvas_gantt/releases)
 [![Redmine](https://img.shields.io/badge/Redmine-6.x-red)](#requirements)
 [![Ruby](https://img.shields.io/badge/Ruby-3.x-cc342d)](#requirements)
 [![Node.js](https://img.shields.io/badge/Node.js-20%2B-339933)](#requirements)
 
-[English README](README.md) · [Issues](https://github.com/tiohsa/redmine_canvas_gantt/issues)
+[English README](README.md) · [Releases](https://github.com/tiohsa/redmine_canvas_gantt/releases) · [Issues](https://github.com/tiohsa/redmine_canvas_gantt/issues)
 
 </div>
 
@@ -20,19 +22,87 @@ https://www.redmine.org/plugins/redmine_canvas_gantt
 
 ## Overview
 
-Redmine Canvas Gantt は、タイムラインを HTML5 Canvas で描画しつつ左側のサイドバーを直接編集できる、Redmine 向けの高速なガントチャートプラグインです。標準の Redmine ガントが見づらい、または重くなりやすいプロジェクト向けに設計されています。
+Redmine Canvas Gantt は、HTML5 Canvas を利用してタイムラインを高速描画しながら、左側サイドバーを直接編集できる Redmine 向けガントチャートプラグインです。
+
+標準 Redmine ガントでは扱いづらい大規模スケジュールを、より高速・直感的・実用的に操作できるよう設計されています。
+
+また、Redmine 標準クエリ連携、インライン編集、依存関係編集、ベースライン比較、共有ビュー機能などを備えつつ、Redmine の DB スキーマ変更なしで導入できます。
+
+## 現在バージョン
+
+- プラグインバージョン: `0.8.4`
+- 対応 Redmine: Redmine 6.x
+- DB マイグレーション: なし
+- project module: `Canvas Gantt`
+- 権限:
+  - `view_canvas_gantt`
+  - `edit_canvas_gantt`
 
 ## Features
 
-- Canvas ベースの高速描画による滑らかなスクロールとズーム
-- タスクの移動、期間変更、端点ドラッグによる依存関係作成
-- 依存関係の作成、更新、削除に対応
+### ガント・スケジュール操作
+
+- Canvas ベースの高速タイムライン描画
+- 滑らかな横・縦スクロール
+- Ctrl/Cmd + マウスホイールによるズーム
+- ドラッグによるタスク移動
+- タスク端ドラッグによる開始日・期日変更
+- バージョンヘッダー、進捗ライン、階層線、タスクタイトル、行高プリセット対応
+- 高 DPI 環境向け devicePixelRatio 対応 Canvas 描画
+
+### 依存関係管理
+
+- タスク端点からのドラッグによる依存関係作成
+- relation type と delay の編集
+- 依存関係削除
+- 依存関係ベースの並び替え表示
+
+### チケット編集
+
 - 件名、担当者、ステータス、進捗率、期日、カスタムフィールドのインライン編集
-- サイドバーでのドラッグアンドドロップによる親子関係の変更
+- サイドバーでのドラッグアンドドロップによる親子関係変更
 - 複数行入力による子チケット一括作成
-- フィルタ結果単位または project 全体で保存できるベースライン比較
-- プロジェクト、担当者、ステータス、バージョン、題名によるフィルタとグループ化
-- バージョンヘッダー、進捗ライン、行高プリセット、UI 設定の永続化
+- プラグイン設定からインライン編集項目を切替可能
+
+### フィルタ・クエリ・共有ビュー
+
+- プロジェクト、担当者、ステータス、バージョン、題名によるフィルタ
+- project / assigned_to によるグループ化
+- `query_id` による Redmine 保存済みクエリ利用
+- Redmine 保存済みクエリとの表示列・ソート同期
+- Redmine 標準 issue list URL パラメータの一部に対応
+- bare URL 起動時に project 単位の最後の shared state を復元
+- 保存済みクエリやフィルタ有効時にツールバーへインジケータ表示
+
+### 表示設定
+
+- ズーム、表示位置、サイドバー幅などの UI 状態を `localStorage` に保存
+- 表示設定を project 横断で共有可能
+- 共有対象:
+  - ズームレベル
+  - view mode
+  - chart position
+  - progress line
+  - task title
+  - hierarchy lines
+  - orphan point display
+  - version headers
+  - baseline visibility
+  - visible columns
+  - column order
+  - dependency organization
+  - column widths
+  - sidebar width
+  - custom zoom scales
+  - row height
+  - sidebar font size
+
+### ベースライン比較
+
+- 現在フィルタ範囲または project 全体を baseline 保存可能
+- 現在スケジュールと baseline を比較表示
+- ghost bar と diff popover による差分表示
+- baseline は比較専用であり、スケジューリング入力には未使用
 
 ## Demo
 
@@ -44,197 +114,193 @@ Redmine Canvas Gantt は、タイムラインを HTML5 Canvas で描画しつつ
 
 - Redmine 6.x
 - Ruby 3.x
-- SPA ビルドおよびフロントエンド開発用に Node.js 20+
-- Redmine で REST API が有効化されていること
+- SPA ビルドおよびフロントエンド開発用 Node.js 20+
+- Redmine REST API 有効化
 
-### Security and impact
+## Security and Impact
 
-- データベースマイグレーション: なし
-- 追加パーミッション: `view_canvas_gantt`, `edit_canvas_gantt`
-- アンインストール: プラグインディレクトリを削除して Redmine を再起動
+- DB マイグレーションなし
+- 追加権限:
+  - `view_canvas_gantt`
+  - `edit_canvas_gantt`
+- アンインストールはプラグイン削除 + Redmine 再起動のみ
+- フロントエンド build は Redmine plugin assets 経由で配信
 
 ## Installation
 
-1. プラグインを Redmine の `plugins/` ディレクトリに配置します。
+1. プラグインを Redmine の `plugins/` 配下へ clone します。
 
-   ```bash
-   cd /path/to/redmine/plugins
-   git clone https://github.com/tiohsa/redmine_canvas_gantt.git
-   ```
+```bash
+cd /path/to/redmine/plugins
+git clone https://github.com/tiohsa/redmine_canvas_gantt.git
+```
 
-2. Redmine を再起動します。
+2. release package に `assets/build/` が含まれていない場合は SPA を build します。
 
-   配置後にアプリケーションサーバーを再起動してください。
+```bash
+cd redmine_canvas_gantt/spa
+npm ci
+npm run build
+```
+
+3. Redmine を再起動します。
 
 ## Usage
 
 1. REST API を有効化します。
-   **管理** -> **設定** -> **API** で **REST による Web サービスを有効にする** を有効化します。
 
-2. プロジェクトモジュールを有効化します。
-   **プロジェクト** -> **設定** -> **モジュール** で **Canvas Gantt** を有効化します。
+**管理** -> **設定** -> **API** -> **REST による Web サービスを有効にする**
+
+2. project module を有効化します。
+
+**プロジェクト** -> **設定** -> **モジュール** -> **Canvas Gantt**
 
 3. 権限を付与します。
-   **管理** -> **ロールと権限** で `view_canvas_gantt` と `edit_canvas_gantt` を必要に応じて付与します。
 
-4. チャートを開きます。
-   プロジェクトメニューの **Canvas Gantt** をクリックします。
+**管理** -> **ロールと権限**
+
+- `view_canvas_gantt`
+- `edit_canvas_gantt`
+
+4. project menu の **Canvas Gantt** を開きます。
 
 5. タスクを操作します。
-   - Ctrl/Cmd + マウスホイールまたはツールバーでズーム
-   - タスクをドラッグしてタイムライン上で移動
-   - タスク端をドラッグして期間変更
-   - 端点ドットからドラッグして依存関係を作成
-   - 依存関係編集から種別や delay を変更、または削除
-   - サイドバーの行を別タスクへドラッグして子チケット化
-   - 子チケット一括作成で複数の子チケットをまとめて追加
 
-### ベースライン比較
+- Ctrl/Cmd + ホイールでズーム
+- タスクドラッグで移動
+- タスク端ドラッグで期間変更
+- 端点ドットドラッグで依存関係作成
+- relation 編集 UI から relation type / delay 編集
+- sidebar row drag & drop による子チケット化
+- bulk subtask create による複数子チケット追加
 
-- ベースラインは比較専用機能であり、スケジューリングや CPM 計算の入力には使いません。
-- project ごとに単一のベースライン snapshot を保持し、新しく保存すると既存 snapshot を置き換えます。
-- ツールバーから `現在のフィルタ結果` または `project 全体` のどちらを保存するか選べます。
-- 保存範囲が `project 全体` でも、画面上の ghost bar と差分表示は現在表示中のタスクに対してのみ行われます。
-- ベースラインの閲覧には `view_canvas_gantt`、保存には `edit_canvas_gantt` が必要です。
+## ベースライン比較
 
-## 共有ビューとクエリパラメータ
+baseline は現在スケジュールとの差分比較機能です。
 
-Canvas Gantt では、共有すべき業務条件と個人向けの UI 状態を分離して扱います。
+- scheduling / CPM 計算入力には利用しません
+- project ごとに単一 baseline snapshot を保持
+- 新規保存時に既存 snapshot を置換
+- toolbar から「現在フィルタ」または「project 全体」を保存可能
+- ghost bar と diff 表示は現在表示中タスクのみ描画
+- baseline 閲覧には `view_canvas_gantt`
+- baseline 保存には `edit_canvas_gantt`
 
-- 共有用の業務条件は URL パラメータと `query_id` から解決されます
-- ズーム、スクロール位置、サイドバー幅、表示列などの UI 状態は `localStorage` に保存されます
-- `Canvas Gantt` タブが bare `/canvas_gantt` を開いた場合に限り、共有クエリ条件はそのプロジェクトで最後に使った状態を `localStorage` から復元します
-- 同じ共有条件が複数ソースにある場合の優先順位は次の通りです
-  URL パラメータ -> 保存済みクエリ (`query_id`) -> project 単位の last-used shared state -> デフォルト値
+## Shared Views と Query Parameters
 
-### クエリ編集の流れ
+Canvas Gantt は、共有すべき業務条件と個人 UI 状態を分離して管理します。
 
-Canvas Gantt は Redmine 標準のクエリ編集 UI を再実装しません。クエリの作成、編集、保存は Redmine 標準のチケット一覧で行い、Canvas Gantt は保存済みクエリと、対応済みの Redmine 標準 URL パラメータを受け取って表示に反映します。
-
-- Canvas Gantt のツールバーにある **Redmineでクエリ編集** で、現在のプロジェクトの標準チケット一覧を開きます
-- Redmine 標準の一覧画面でフィルタ条件を調整し、標準の **Save** でクエリを保存します
-- 一覧画面の **Canvas Ganttで開く** で、現在のチケット一覧 URL 状態を引き継いだまま Canvas Gantt に戻ります
-- 保存済みクエリを表示している場合は、戻り先 URL に `query_id` が含まれます
-- 未保存の標準フィルタを表示している場合は、対応している Redmine 標準 filter パラメータをそのまま引き継ぎます
-
-現在の表示が保存済みクエリそのものと一致している場合は `query_id` だけで十分です。保存済みクエリを開いたあとに Canvas Gantt 側で共有条件を追加変更した場合は、ツールバーから Redmine 一覧へ戻る際に `query_id` に加えて Redmine 標準の filter パラメータも付与し、可能な範囲で同じ表示条件を再現します。
-
-project menu の `Canvas Gantt` タブが shared query なしの bare URL を開いた場合は、その project で最後に使った shared filter 状態を復元し、browser URL も canonical な shared query params に書き換えます。
-
-### 対応している共有パラメータ
-
-- `query_id`: Redmine の保存済みチケットクエリを基底条件として使います。保存済みのクエリ ID のみ対応します
-- `status_ids[]`: ステータス ID で絞り込みます
-- `assigned_to_ids[]`: 担当者 ID で絞り込みます。未割当は `none` を使います
-- `project_ids[]`: 現在のプロジェクト配下で表示対象のプロジェクトを絞り込みます
-- `fixed_version_ids[]`: 対象バージョン ID で絞り込みます。未設定は `none` を使います
-- `group_by`: `project` または `assigned_to`
-- `sort`: フロントエンドのソートキーと方向を指定します。例: `subject:asc`, `startDate:desc`
-- `show_subprojects`: `0` でサブプロジェクト非表示、未指定または `1` で表示
-
-さらに、以下の Redmine 標準チケット一覧パラメータも読めます:
-
-- `set_filter=1`
-- `f[]`
-- `op[field]`
-- `v[field][]`
-- `group_by`
-- `sort`
-
-対応している Redmine 標準 field:
-
-- `status_id`
-- `assigned_to_id`
-- `project_id`
-- `fixed_version_id`
-- `subproject_id`
-
-対応している Redmine 標準 operator:
-
-- `=`
-- `*`
-- `!*`
-- `o`
-- `c`
-
-現在の互換性の制限:
-
-- 未対応の Redmine field / operator は warning を出して無視します
-- `assigned_to_id` の「特定担当者 + 未割当」を同時に Redmine 標準 URL へ完全に書き戻すことはできないため、未割当側を省略して warning を出します
-- バージョンなしは Canvas 独自 URL では `fixed_version_ids[]=none` で表現できますが、Redmine 標準の一覧 URL へ戻すときは省略されます
-- 既定ソート (`startDate:asc`) は Redmine 一覧 URL へ戻すときに省略されることがあります
-
-### URL 例
-
-保存済みクエリを基底にして開く:
+- shared business condition は URL と `query_id` から解決
+- zoom / viewport / sidebar width などの個人 UI 状態は `localStorage` 保存
+- display columns と sorting は shared state として Redmine query と同期
+- `query_id` や filter 条件は global display preference としては共有しない
+- bare `/canvas_gantt` 起動時は project ごとの last-used shared state を復元
+- 優先順位:
 
 ```text
-/projects/demo/canvas_gantt?query_id=12
+URL parameters -> saved query (`query_id`) -> project-scoped last-used shared state -> defaults
 ```
 
-保存済みクエリにステータスと担当者条件を上書きする:
+### クエリ編集フロー
 
-```text
-/projects/demo/canvas_gantt?query_id=12&status_ids[]=1&status_ids[]=2&assigned_to_ids[]=5
-```
+Canvas Gantt は Redmine 標準 query editor を再実装しません。
 
-対応済みの Redmine 標準チケット一覧 URL から直接 Canvas Gantt を開く:
+クエリ作成・編集・保存は Redmine 標準 issue list 側で行い、Canvas Gantt は保存済み query と対応済み URL parameter を解釈します。
 
-```text
-/projects/demo/canvas_gantt?query_id=12&set_filter=1&f[]=status_id&op[status_id]==&v[status_id][]=1&group_by=assigned_to&sort=start_date:desc
-```
+- toolbar の **Saved Queries** から query 選択
+- `query_id` により saved query を適用
+- **Clear saved query** で `query_id` のみ解除
+- **Save custom query** で iframe dialog から Redmine 標準 query 保存
+- **Edit Query in Redmine** で標準 issue list を開く
+- issue list 側の **Open in Canvas Gantt** で戻る
+- saved query 時は `query_id` を引き継ぐ
+- unsaved filter 時は Redmine 標準 parameter を引き継ぐ
 
-ブラウザ保存状態に依存せず、特定プロジェクト・特定バージョンの共有ビューを開く:
+iframe query editor dialog には **Open in new tab** fallback もあります。
 
-```text
-/projects/demo/canvas_gantt?project_ids[]=3&fixed_version_ids[]=7&group_by=project&sort=startDate:asc
-```
+### 対応 shared parameters
 
-サブプロジェクトを隠し、未割当チケットだけを表示する:
+| Parameter | 内容 |
+| :--- | :--- |
+| `query_id` | Redmine 保存済み query を基底条件として利用 |
+| `status_ids[]` | ステータス絞り込み |
+| `assigned_to_ids[]` | 担当者絞り込み (`none` で未割当) |
+| `project_ids[]` | project 絞り込み |
+| `fixed_version_ids[]` | version 絞り込み (`none` で未設定) |
+| `group_by` | `project` または `assigned_to` |
+| `sort` | frontend sort 指定 |
+| `c[]` | visible columns 指定 |
+| `show_subprojects` | subproject 表示制御 |
 
-```text
-/projects/demo/canvas_gantt?assigned_to_ids[]=none&show_subprojects=0
-```
+### Redmine issue list 互換
+
+| Category | Supported |
+| :--- | :--- |
+| Parameters | `set_filter=1`, `f[]`, `op[field]`, `v[field][]`, `c[]`, `group_by`, `sort` |
+| Fields | `status_id`, `assigned_to_id`, `project_id`, `fixed_version_id`, `subproject_id` |
+| Operators | `=`, `*`, `!*`, `o`, `c` |
+
+現在の制限:
+
+- 未対応 field/operator は warning 表示して無視
+- `assigned_to_id` の「担当者 + 未割当」同時表現は完全再現不可
+- `fixed_version_ids[]=none` は Redmine 標準 URL export 時に省略
+- default sort は export 時に省略される場合あり
 
 ## Configuration
 
-**管理** -> **プラグイン** -> **Canvas Gantt** -> **設定** から設定します。
+**管理** -> **プラグイン** -> **Canvas Gantt** -> **設定**
 
-- インライン編集切替: `subject`, `assigned_to`, `status`, `done_ratio`, `due_date`, `custom_fields`
-- `row_height`: デフォルト行高
-- `use_vite_dev_server`: 開発時に `http://localhost:5173` のフロントエンド資産を利用
+| Setting | 内容 |
+| :--- | :--- |
+| `inline_edit_subject` | 件名インライン編集 |
+| `inline_edit_assigned_to` | 担当者インライン編集 |
+| `inline_edit_status` | ステータスインライン編集 |
+| `inline_edit_done_ratio` | 進捗率インライン編集 |
+| `inline_edit_due_date` | 期日インライン編集 |
+| `inline_edit_custom_fields` | カスタムフィールド編集 |
+| `row_height` | デフォルト行高 |
+| `use_vite_dev_server` | 開発時 Vite dev server 使用 |
 
 ### Compatibility note
 
-`redmica_ui_extension` による Select2 の挙動が Canvas Gantt の操作に干渉する場合は、**管理** -> **プラグイン** -> **Redmica UI Extension** -> **設定** で検索可能セレクトボックスを無効化してください。
+`redmica_ui_extension` の Select2 が干渉する場合:
+
+**管理** -> **プラグイン** -> **Redmica UI Extension** -> **設定**
+
+で searchable select box を無効化してください。
 
 ## Docker Quick Start
 
-このリポジトリには、Redmine 6.0 と MariaDB をローカルで起動するための `docker-compose.yml` が含まれています。
+この repository には Redmine 6 + MariaDB 用 `docker-compose.yml` が含まれています。
 
-### スタックを起動
+### 起動
 
 ```bash
 docker compose up -d --wait
 ```
 
-[http://localhost:3000](http://localhost:3000) で Redmine を開けます。
+Redmine:
 
-### 初期データを投入
+```text
+http://localhost:3000
+```
+
+### 初期データ投入
 
 ```bash
 docker compose exec -T -e REDMINE_LANG=ja redmine bundle exec rake redmine:load_default_data
 docker compose exec -T redmine bundle exec rake db:fixtures:load
 ```
 
-### プロジェクトで Canvas Gantt を有効化
+### Canvas Gantt 有効化
 
-1. 対象プロジェクトを開きます。
-2. **設定** -> **モジュール** を開きます。
-3. **Canvas Gantt** を有効化します。
-4. 編集が必要な場合は、利用ロールに `view_canvas_gantt` と `edit_canvas_gantt` を付与します。
+1. project を開く
+2. **設定** -> **モジュール**
+3. **Canvas Gantt** を有効化
+4. role に権限付与
 
-### スタックを停止
+### 停止
 
 ```bash
 docker compose down
@@ -242,7 +308,7 @@ docker compose down
 
 ## Development
 
-SPA フロントエンドは `spa/` にあります。
+SPA frontend は `spa/` 配下です。
 
 ```bash
 cd spa
@@ -252,18 +318,16 @@ npm run lint
 npm run test -- --run
 ```
 
-フロントエンドをライブ開発する場合:
+live frontend development:
 
 ```bash
 cd spa
 npm run dev
 ```
 
-その後、プラグイン設定で `use_vite_dev_server` を有効化してください。
+その後 plugin setting の `use_vite_dev_server` を有効化してください。
 
 ### Redmine integration tests
-
-`spa/` から Redmine 連携の Playwright テストを実行できます。
 
 ```bash
 npx playwright test -c playwright.redmine.config.ts
@@ -271,10 +335,27 @@ npx playwright test -c playwright.redmine.config.ts
 
 ## Build Output
 
-- `npm run build` の出力先は `assets/build/`
-- Redmine 起動時に、それらのファイルは `public/plugin_assets/redmine_canvas_gantt/build` へリンクまたはコピーされます
-- フォールバック資産ルート `/plugin_assets/redmine_canvas_gantt/build/*` も利用できます
+- `npm run build` 出力先: `assets/build/`
+- Redmine 起動時に `public/plugin_assets/redmine_canvas_gantt/build` へ link/copy
+- fallback route:
+
+```text
+/plugin_assets/redmine_canvas_gantt/build/*
+```
+
+## Release
+
+`v*` tag push 時に GitHub Release が自動生成されます。
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+release workflow は GitHub Release 作成のみ行い、SPA build artifact packaging は行いません。
 
 ## License
 
-GNU General Public License v2.0 (GPL v2). 詳細は [LICENSE](LICENSE) を参照してください。
+GNU General Public License v2.0 (GPL v2)
+
+詳細は [LICENSE](LICENSE) を参照してください。


### PR DESCRIPTION
## Summary

This PR updates `README.md` to better reflect the current Canvas Gantt feature set and usage model.

## Changes

- Clarifies the plugin purpose and current version metadata
- Adds current version, supported Redmine version, permissions, and migration impact
- Reorganizes the feature list into focused sections:
  - Gantt and schedule operation
  - Dependency management
  - Issue editing
  - Filters, queries, and shared views
  - Display preferences
  - Baseline snapshots
- Documents high-DPI Canvas rendering support
- Expands shared view and Redmine query parameter behavior
- Converts supported shared parameters and plugin settings into tables
- Adds SPA build step to installation guidance
- Keeps Docker, development, build output, and release guidance aligned with the current repository structure

## Testing

Documentation-only change. No runtime tests were executed.

## Risk

Low. This PR changes only README documentation.