### PR TITLE
Add uninstall cleanup for plugin settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Use a current desktop version of Chrome, Edge, Firefox, or Safari with HTML5 Can
 
 - Database migration: none
 - Added permissions: `view_canvas_gantt`, `edit_canvas_gantt`
-- Uninstall: remove the plugin directory and restart Redmine. Redmine plugin settings, including stored baselines, and each user's browser `localStorage` are not automatically deleted; remove them separately if data removal is required.
+- Uninstall: run `bundle exec rake redmine_canvas_gantt:uninstall RAILS_ENV=production` before removing the plugin directory. The task deletes the complete Redmine plugin settings row, including stored baselines. Browser `localStorage` remains local to each user and is not removed by the server-side task.
 
 ## Installation
 
@@ -99,7 +99,21 @@ Use a current desktop version of Chrome, Edge, Firefox, or Safari with HTML5 Can
 3. If you build the SPA from source, run `cd spa && npm ci && npm run build` with Node.js 20+.
 4. Restart Redmine and verify the plugin module and permissions.
 
-This plugin does not provide database migrations. Existing baselines in Redmine settings and browser display preferences are retained unless you remove them explicitly.
+This plugin does not provide database migrations. Existing baselines in Redmine settings and browser display preferences are retained during upgrades.
+
+### Uninstall
+
+1. Back up the Redmine database if stored baselines or plugin settings may be needed later.
+2. Run the idempotent cleanup task while the plugin directory is still present.
+
+   ```bash
+   bundle exec rake redmine_canvas_gantt:uninstall RAILS_ENV=production
+   ```
+
+3. Remove the `plugins/redmine_canvas_gantt` directory.
+4. Restart Redmine.
+
+The cleanup task deletes the `plugin_redmine_canvas_gantt` row from Redmine's `settings` table, including all baseline snapshots and plugin defaults stored there. It does not clear browser `localStorage`.
 
 ## Usage
 
@@ -135,7 +149,7 @@ This plugin does not provide database migrations. Existing baselines in Redmine 
 - The toolbar lets you save either the current filtered view or the whole project as the baseline scope.
 - Baseline bars and diff popovers only render for tasks currently visible in the chart, even when the saved scope was the whole project.
 - Viewing baseline comparison requires `view_canvas_gantt`. Saving a baseline requires `edit_canvas_gantt`.
-- Baselines are stored in `Setting.plugin_redmine_canvas_gantt` in Redmine's settings area. They are not shared through the browser URL, and they are not removed automatically when the plugin directory is deleted.
+- Baselines are stored in `Setting.plugin_redmine_canvas_gantt` in Redmine's settings area. Removing the plugin directory alone does not delete them; run the uninstall cleanup task first.
 
 ### Workload, display settings, and export
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Use a current desktop version of Chrome, Edge, Firefox, or Safari with HTML5 Can
 
 - Database migration: none
 - Added permissions: `view_canvas_gantt`, `edit_canvas_gantt`
-- Uninstall: run `bundle exec rake redmine_canvas_gantt:uninstall RAILS_ENV=production` before removing the plugin directory. The task deletes the complete Redmine plugin settings row, including stored baselines. Browser `localStorage` remains local to each user and is not removed by the server-side task.
+- Uninstall: run the cleanup task from the Redmine application environment before removing the plugin directory. For Docker Compose, run it inside the `redmine` service container. The task deletes the complete Redmine plugin settings row, including stored baselines. Browser `localStorage` remains local to each user and is not removed by the server-side task.
 
 ## Installation
 
@@ -106,11 +106,30 @@ This plugin does not provide database migrations. Existing baselines in Redmine 
 1. Back up the Redmine database if stored baselines or plugin settings may be needed later.
 2. Run the idempotent cleanup task while the plugin directory is still present.
 
+   **Standard installation** — run from the Redmine application directory that contains `Gemfile`:
+
    ```bash
+   cd /path/to/redmine
    bundle exec rake redmine_canvas_gantt:uninstall RAILS_ENV=production
    ```
 
-3. Remove the `plugins/redmine_canvas_gantt` directory.
+   **Docker Compose** — run inside the Redmine service container:
+
+   ```bash
+   docker compose exec -T redmine \
+     bundle exec rake redmine_canvas_gantt:uninstall
+   ```
+
+   `RAILS_ENV=production` is already configured in this repository's Compose service. To set it explicitly:
+
+   ```bash
+   docker compose exec -T -e RAILS_ENV=production redmine \
+     bundle exec rake redmine_canvas_gantt:uninstall
+   ```
+
+   Do not run `bundle exec` from the host plugin directory when Redmine itself runs only in Docker. The host directory does not contain Redmine's `Gemfile`, so Bundler reports `Could not locate Gemfile or .bundle/ directory`.
+
+3. Remove the `plugins/redmine_canvas_gantt` directory, or remove the corresponding plugin volume or bind mount from the container configuration.
 4. Restart Redmine.
 
 The cleanup task deletes the `plugin_redmine_canvas_gantt` row from Redmine's `settings` table, including all baseline snapshots and plugin defaults stored there. It does not clear browser `localStorage`.

--- a/README_ja.md
+++ b/README_ja.md
@@ -65,7 +65,7 @@ Edge、Firefox、Safari を使用してください。Internet Explorer は対�
 
 - データベースマイグレーション: なし
 - 追加パーミッション: `view_canvas_gantt`, `edit_canvas_gantt`
-- アンインストール: プラグインディレクトリを削除して Redmine を再起動します。Redmine のプラグイン設定（保存済みベースラインを含む）と各ユーザーのブラウザ `localStorage` は自動削除されないため、完全に削除する場合は別途対応してください。
+- アンインストール: プラグインディレクトリを削除する前に `bundle exec rake redmine_canvas_gantt:uninstall RAILS_ENV=production` を実行します。このタスクは保存済みベースラインを含む Redmine のプラグイン設定行全体を削除します。各ユーザーのブラウザ `localStorage` はサーバー側タスクでは削除されません。
 
 ## インストール
 
@@ -88,7 +88,21 @@ Edge、Firefox、Safari を使用してください。Internet Explorer は対�
 4. Redmine を再起動し、プラグインのモジュールと権限を確認します。
 
 データベースマイグレーションはありません。Redmine 設定内のベースラインとブラウザの
-表示設定は、明示的に削除しない限り保持されます。
+表示設定は、アップグレード時には保持されます。
+
+### アンインストール
+
+1. 保存済みベースラインやプラグイン設定を後で利用する可能性がある場合は、Redmine データベースをバックアップします。
+2. プラグインディレクトリが存在する状態で、冪等なクリーンアップタスクを実行します。
+
+   ```bash
+   bundle exec rake redmine_canvas_gantt:uninstall RAILS_ENV=production
+   ```
+
+3. `plugins/redmine_canvas_gantt` ディレクトリを削除します。
+4. Redmine を再起動します。
+
+クリーンアップタスクは Redmine の `settings` テーブルから `plugin_redmine_canvas_gantt` 行を削除し、保存済みベースラインと同じ行に保存されたプラグイン設定をすべて削除します。ブラウザの `localStorage` は削除しません。
 
 ## 使い方
 
@@ -124,7 +138,7 @@ Edge、Firefox、Safari を使用してください。Internet Explorer は対�
 - ツールバーから `現在のフィルタ結果` または `プロジェクト全体` のどちらを保存するかを選べます。
 - 保存範囲が `プロジェクト全体` でも、ゴーストバーと差分 popover は現在表示中のタスクに対してのみ表示されます。
 - ベースラインの閲覧には `view_canvas_gantt`、保存には `edit_canvas_gantt` が必要です。
-- ベースラインは Redmine の設定領域 `Setting.plugin_redmine_canvas_gantt` に保存されます。ブラウザ URL を通じて共有されず、プラグインディレクトリを削除しても自動削除されません。
+- ベースラインは Redmine の設定領域 `Setting.plugin_redmine_canvas_gantt` に保存されます。プラグインディレクトリを削除するだけでは残るため、先にアンインストール用クリーンアップタスクを実行してください。
 
 ### ワークロード、表示設定、出力
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -65,7 +65,7 @@ Edge、Firefox、Safari を使用してください。Internet Explorer は対�
 
 - データベースマイグレーション: なし
 - 追加パーミッション: `view_canvas_gantt`, `edit_canvas_gantt`
-- アンインストール: プラグインディレクトリを削除する前に `bundle exec rake redmine_canvas_gantt:uninstall RAILS_ENV=production` を実行します。このタスクは保存済みベースラインを含む Redmine のプラグイン設定行全体を削除します。各ユーザーのブラウザ `localStorage` はサーバー側タスクでは削除されません。
+- アンインストール: プラグインディレクトリを削除する前に、Redmine の実行環境からクリーンアップタスクを実行します。Docker Compose の場合は `redmine` サービスのコンテナ内で実行します。このタスクは保存済みベースラインを含む Redmine のプラグイン設定行全体を削除します。各ユーザーのブラウザ `localStorage` はサーバー側タスクでは削除されません。
 
 ## インストール
 
@@ -95,11 +95,30 @@ Edge、Firefox、Safari を使用してください。Internet Explorer は対�
 1. 保存済みベースラインやプラグイン設定を後で利用する可能性がある場合は、Redmine データベースをバックアップします。
 2. プラグインディレクトリが存在する状態で、冪等なクリーンアップタスクを実行します。
 
+   **通常インストール** — `Gemfile` が存在する Redmine 本体ディレクトリで実行します。
+
    ```bash
+   cd /path/to/redmine
    bundle exec rake redmine_canvas_gantt:uninstall RAILS_ENV=production
    ```
 
-3. `plugins/redmine_canvas_gantt` ディレクトリを削除します。
+   **Docker Compose** — Redmine サービスのコンテナ内で実行します。
+
+   ```bash
+   docker compose exec -T redmine \
+     bundle exec rake redmine_canvas_gantt:uninstall
+   ```
+
+   このリポジトリの Compose 設定では `RAILS_ENV=production` が設定済みです。明示する場合は次のように実行します。
+
+   ```bash
+   docker compose exec -T -e RAILS_ENV=production redmine \
+     bundle exec rake redmine_canvas_gantt:uninstall
+   ```
+
+   Redmine 本体が Docker 内だけで動作している場合、ホスト側のプラグインディレクトリでは `bundle exec` を実行しないでください。ホスト側には Redmine の `Gemfile` がないため、Bundler が `Could not locate Gemfile or .bundle/ directory` を出力します。
+
+3. `plugins/redmine_canvas_gantt` ディレクトリを削除します。Docker の場合は、対応するプラグインの volume または bind mount もコンテナ設定から削除します。
 4. Redmine を再起動します。
 
 クリーンアップタスクは Redmine の `settings` テーブルから `plugin_redmine_canvas_gantt` 行を削除し、保存済みベースラインと同じ行に保存されたプラグイン設定をすべて削除します。ブラウザの `localStorage` は削除しません。

--- a/lib/redmine_canvas_gantt/settings_cleanup.rb
+++ b/lib/redmine_canvas_gantt/settings_cleanup.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module RedmineCanvasGantt
+  class SettingsCleanup
+    SETTING_NAME = 'plugin_redmine_canvas_gantt'.freeze
+
+    def initialize(setting_model: nil)
+      @setting_model = setting_model || Setting
+    end
+
+    def call
+      deleted_count = @setting_model.where(name: SETTING_NAME).delete_all
+      @setting_model.clear_cache if @setting_model.respond_to?(:clear_cache)
+      deleted_count
+    end
+  end
+end

--- a/lib/tasks/redmine_canvas_gantt.rake
+++ b/lib/tasks/redmine_canvas_gantt.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative '../redmine_canvas_gantt/settings_cleanup'
+
+namespace :redmine_canvas_gantt do
+  desc 'Remove Redmine Canvas Gantt plugin settings, including stored baselines'
+  task uninstall: :environment do
+    deleted_count = RedmineCanvasGantt::SettingsCleanup.new.call
+
+    if deleted_count.positive?
+      puts 'Removed Redmine Canvas Gantt plugin settings and stored baselines.'
+    else
+      puts 'No Redmine Canvas Gantt plugin settings were found.'
+    end
+  end
+end

--- a/spec/lib/redmine_canvas_gantt/settings_cleanup_spec.rb
+++ b/spec/lib/redmine_canvas_gantt/settings_cleanup_spec.rb
@@ -1,0 +1,35 @@
+require_relative '../../spec_helper'
+require_relative '../../../lib/redmine_canvas_gantt/settings_cleanup'
+
+RSpec.describe RedmineCanvasGantt::SettingsCleanup do
+  subject(:cleanup) { described_class.new }
+
+  before do
+    Setting.plugin_redmine_canvas_gantt = {
+      'row_height' => '36',
+      'baseline_snapshots' => {
+        '1' => {
+          'snapshot_id' => 'baseline-1',
+          'project_id' => 1
+        }
+      }
+    }
+    Setting.clear_cache
+  end
+
+  after do
+    Setting.where(name: described_class::SETTING_NAME).delete_all
+    Setting.clear_cache
+  end
+
+  it 'deletes the complete plugin settings row including stored baselines' do
+    expect(cleanup.call).to eq(1)
+    expect(Setting.where(name: described_class::SETTING_NAME)).not_to exist
+  end
+
+  it 'is idempotent when the settings row does not exist' do
+    cleanup.call
+
+    expect(cleanup.call).to eq(0)
+  end
+end


### PR DESCRIPTION
## Summary

- Add an idempotent uninstall task that removes the `plugin_redmine_canvas_gantt` settings row.
- Remove stored baseline snapshots together with the plugin settings.
- Document the uninstall procedure in English and Japanese.

## Background

Baseline snapshots are stored in Redmine's plugin settings rather than a dedicated table. Removing the plugin directory does not delete that settings row, so baseline data remains after uninstall.

Redmine does not provide a directory-removal lifecycle hook. This change keeps the plugin database-migration-free and provides an explicit cleanup task that must be run before removing the plugin directory.

## Changes

- Add `RedmineCanvasGantt::SettingsCleanup`.
- Add `redmine_canvas_gantt:uninstall` Rake task.
- Clear Redmine's settings cache after deletion.
- Add coverage for deletion and idempotency.
- Update `README.md` and `README_ja.md` with the uninstall command and data-removal scope.

## Testing

- [ ] Run `bundle exec rspec plugins/redmine_canvas_gantt/spec/lib/redmine_canvas_gantt/settings_cleanup_spec.rb`
- [ ] Run `bundle exec rake redmine_canvas_gantt:uninstall RAILS_ENV=test` against a Redmine test environment
- [ ] Confirm the existing frontend CI passes

## Risks

- The cleanup task intentionally deletes the complete plugin settings row, not only `baseline_snapshots`.
- Browser `localStorage` remains on each client and is outside the server-side uninstall task.
- Removing the plugin directory without running the task still leaves the settings row in Redmine.
