### PR TITLE
feat(permission): replace edit_canvas_gantt with manage_canvas_gantt_…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ Redmine Canvas Gantt は、Ruby on Rails バックエンドと `spa/` ディレ�
 
 - API キー、トークン、機密情報をコミットしないでください。
 - 機密設定は環境変数または Redmine の設定機能内に保持してください。
-- Redmine の権限設定である `view_canvas_gantt` および `edit_canvas_gantt` を尊重し、正しく適用してください。
+- Canvas Gantt へのアクセスは `view_canvas_gantt`、Baseline 保存は `manage_canvas_gantt_baseline` を尊重してください。Issue 操作は対象IssueのProjectに対する Redmine 標準権限を使用してください。
 - `/plugin_assets/redmine_canvas_gantt/build/*` 周辺のアセットパスの安全検証処理を維持し、壊さないようにしてください。
 
 ## リポジトリのレイアウト (Repository Layout)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Use a current desktop version of Chrome, Edge, Firefox, or Safari with HTML5 Can
 ### Security and impact
 
 - Database migration: none
-- Added permissions: `view_canvas_gantt`, `edit_canvas_gantt`
+- Added permissions: `view_canvas_gantt`, `manage_canvas_gantt_baseline`
 - Uninstall: run the cleanup task from the Redmine application environment before removing the plugin directory. For Docker Compose, run it inside the `redmine` service container. The task deletes the complete Redmine plugin settings row, including stored baselines. Browser `localStorage` remains local to each user and is not removed by the server-side task.
 
 ## Installation
@@ -143,7 +143,9 @@ The cleanup task deletes the `plugin_redmine_canvas_gantt` row from Redmine's `s
    Open **Project** -> **Settings** -> **Modules** and enable **Canvas Gantt**.
 
 3. Grant permissions.
-   In **Administration** -> **Roles and permissions**, grant `view_canvas_gantt` and `edit_canvas_gantt` as needed.
+   In **Administration** -> **Roles and permissions**, grant `view_canvas_gantt` to use Canvas Gantt. Issue actions use Redmine's standard permissions on the target issue's project: `edit_issues`, `delete_issues`, `add_issues`, and `manage_subtasks`. Grant `manage_canvas_gantt_baseline` only to roles allowed to save a baseline.
+
+   When upgrading from a version that used `edit_canvas_gantt`, review affected roles: that retired permission is not migrated automatically. Grant `manage_canvas_gantt_baseline` only where baseline saving should remain available; no Canvas-specific permission is needed for normal Issue actions.
 
 4. Open the chart.
    Click **Canvas Gantt** from the project menu.
@@ -167,7 +169,7 @@ The cleanup task deletes the `plugin_redmine_canvas_gantt` row from Redmine's `s
 - Each project stores a single baseline snapshot, and saving a new one replaces the previous snapshot.
 - The toolbar lets you save either the current filtered view or the whole project as the baseline scope.
 - Baseline bars and diff popovers only render for tasks currently visible in the chart, even when the saved scope was the whole project.
-- Viewing baseline comparison requires `view_canvas_gantt`. Saving a baseline requires `edit_canvas_gantt`.
+- Viewing baseline comparison requires `view_canvas_gantt`. Saving a baseline requires `manage_canvas_gantt_baseline`.
 - Baselines are stored in `Setting.plugin_redmine_canvas_gantt` in Redmine's settings area. Removing the plugin directory alone does not delete them; run the uninstall cleanup task first.
 
 ### Workload, display settings, and export
@@ -318,7 +320,7 @@ docker compose exec -T redmine bundle exec rake db:fixtures:load
 1. Open the target project.
 2. Go to **Settings** -> **Modules**.
 3. Enable **Canvas Gantt**.
-4. Ensure the active role has `view_canvas_gantt` and `edit_canvas_gantt` if editing is required.
+4. Ensure the active role has `view_canvas_gantt` and the relevant standard Issue permissions if editing is required. To save baselines, also grant `manage_canvas_gantt_baseline`.
 
 ### Stop the stack
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -64,7 +64,7 @@ Edge、Firefox、Safari を使用してください。Internet Explorer は対�
 ### セキュリティと影響
 
 - データベースマイグレーション: なし
-- 追加パーミッション: `view_canvas_gantt`, `edit_canvas_gantt`
+- 追加パーミッション: `view_canvas_gantt`, `manage_canvas_gantt_baseline`
 - アンインストール: プラグインディレクトリを削除する前に、Redmine の実行環境からクリーンアップタスクを実行します。Docker Compose の場合は `redmine` サービスのコンテナ内で実行します。このタスクは保存済みベースラインを含む Redmine のプラグイン設定行全体を削除します。各ユーザーのブラウザ `localStorage` はサーバー側タスクでは削除されません。
 
 ## インストール
@@ -132,7 +132,9 @@ Edge、Firefox、Safari を使用してください。Internet Explorer は対�
    **プロジェクト** -> **設定** -> **モジュール** で **Canvas Gantt** を有効化します。
 
 3. 権限を付与します。
-   **管理** -> **ロールと権限** で `view_canvas_gantt` と `edit_canvas_gantt` を必要に応じて付与します。
+   **管理** -> **ロールと権限** で Canvas Gantt の利用には `view_canvas_gantt` を付与します。Issue 操作は対象IssueのProjectに対する Redmine 標準権限 `edit_issues`、`delete_issues`、`add_issues`、`manage_subtasks` で制御します。Baseline 保存を許可するロールにだけ `manage_canvas_gantt_baseline` を付与します。
+
+   `edit_canvas_gantt` を使用していたバージョンから更新する場合は、該当ロールを確認してください。この廃止権限は自動移行されません。Baseline 保存を継続するロールだけに `manage_canvas_gantt_baseline` を付与し、通常のIssue操作にCanvas固有権限は不要です。
 
 4. チャートを開きます。
    プロジェクトメニューの **Canvas Gantt** をクリックします。
@@ -156,7 +158,7 @@ Edge、Firefox、Safari を使用してください。Internet Explorer は対�
 - プロジェクトごとに単一のベースライン snapshot を保持し、新しく保存すると既存 snapshot を置き換えます。
 - ツールバーから `現在のフィルタ結果` または `プロジェクト全体` のどちらを保存するかを選べます。
 - 保存範囲が `プロジェクト全体` でも、ゴーストバーと差分 popover は現在表示中のタスクに対してのみ表示されます。
-- ベースラインの閲覧には `view_canvas_gantt`、保存には `edit_canvas_gantt` が必要です。
+- ベースラインの閲覧には `view_canvas_gantt`、保存には `manage_canvas_gantt_baseline` が必要です。
 - ベースラインは Redmine の設定領域 `Setting.plugin_redmine_canvas_gantt` に保存されます。プラグインディレクトリを削除するだけでは残るため、先にアンインストール用クリーンアップタスクを実行してください。
 
 ### ワークロード、表示設定、出力
@@ -316,7 +318,7 @@ docker compose exec -T redmine bundle exec rake db:fixtures:load
 1. 対象 project を開きます。
 2. **設定** -> **モジュール** を開きます。
 3. **Canvas Gantt** を有効化します。
-4. 編集が必要な場合は、利用ロールに `view_canvas_gantt` と `edit_canvas_gantt` を付与します。
+4. 編集が必要な場合は、利用ロールに `view_canvas_gantt` と対象IssueのProjectに対する該当する Redmine 標準権限を付与します。Baseline 保存には `manage_canvas_gantt_baseline` も付与します。
 
 ### スタックを停止
 

--- a/app/controllers/canvas_gantts_controller.rb
+++ b/app/controllers/canvas_gantts_controller.rb
@@ -355,9 +355,12 @@ class CanvasGanttsController < ApplicationController
 
   before_action :resolve_canvas_project
   before_action :set_permissions
-  before_action :ensure_view_permission, only: [:index, :data, :queries, :edit_meta]
+  # Every Canvas Gantt endpoint, including JSON mutation endpoints, is part of
+  # the feature gated by this permission. Individual Issue operations perform
+  # their own standard Redmine authorization below.
+  before_action :ensure_view_permission
   skip_forgery_protection only: [:asset]
-  skip_before_action :resolve_canvas_project, :set_permissions, only: [:asset]
+  skip_before_action :resolve_canvas_project, :set_permissions, :ensure_view_permission, only: [:asset]
 
   # GET /plugin_assets/redmine_canvas_gantt/build/*asset_path
   # Fallback asset delivery when public/plugin_assets static serving is disabled.
@@ -686,7 +689,7 @@ class CanvasGanttsController < ApplicationController
   end
 
   def ensure_baseline_edit_permission
-    return true if User.current.allowed_to?(:edit_canvas_gantt, @project)
+    return true if User.current.allowed_to?(:manage_canvas_gantt_baseline, @project)
 
     render json: { error: canvas_gantt_l(:error_canvas_gantt_permission_denied) }, status: :forbidden
     false
@@ -696,7 +699,7 @@ class CanvasGanttsController < ApplicationController
     @permissions ||= {
       editable: User.current.allowed_to?(:edit_issues, @project),
       viewable: User.current.allowed_to?(:view_canvas_gantt, @project),
-      baseline_editable: User.current.allowed_to?(:edit_canvas_gantt, @project)
+      baseline_editable: User.current.allowed_to?(:manage_canvas_gantt_baseline, @project)
     }
   end
 

--- a/docs/manual_ja.md
+++ b/docs/manual_ja.md
@@ -24,7 +24,11 @@ Redmine Canvas Gantt は、Redmine 上のチケットを Canvas ベースのタ�
 | 権限 | 用途 |
 | --- | --- |
 | `view_canvas_gantt` | Canvas Gantt 画面を表示する |
-| `edit_canvas_gantt` | タスク移動、期間変更、依存関係操作、インライン編集などを行う |
+| `manage_canvas_gantt_baseline` | Baseline snapshot を保存・置換する |
+
+Issue の編集は `edit_issues` と対象Issueの `issue.editable?`、削除は `delete_issues`、子Issue作成は `add_issues` と `manage_subtasks`、関連操作は両端のIssueに対する編集可否で判定します。いずれも Canvas を開いた親Projectではなく、対象IssueのProjectの Redmine 標準権限を使用します。
+
+旧バージョンの `edit_canvas_gantt` は廃止しました。既存ロールは自動移行されないため、Baseline 保存を継続するロールだけに `manage_canvas_gantt_baseline` を付与してください。
 
 ### 2.3 画面を開く
 
@@ -259,7 +263,7 @@ Redmine Canvas Gantt は、Redmine 上のチケットを Canvas ベースのタ�
 
 ### 10.2 編集できない
 
-- `edit_canvas_gantt` 権限があるか確認します
+- 対象IssueのProjectで `edit_issues`（削除は `delete_issues`、子Issue作成は `add_issues` と `manage_subtasks`）があるか確認します
 - プラグイン設定で該当項目のインライン編集が有効か確認します
 - 自動保存が OFF の場合は `保存` を押します
 

--- a/init.rb
+++ b/init.rb
@@ -9,8 +9,14 @@ Redmine::Plugin.register :redmine_canvas_gantt do
   author_url 'https://github.com/tiohsa/redmine_canvas_gantt'
 
   project_module :canvas_gantt do
-    permission :view_canvas_gantt, { canvas_gantts: [:index, :data, :queries] }
-    permission :edit_canvas_gantt, { canvas_gantts: [:update, :bulk_create_subtasks, :destroy_relation, :save_baseline] }
+    permission :view_canvas_gantt, {
+      canvas_gantts: [
+        :index, :data, :queries, :edit_meta, :update, :destroy_task,
+        :bulk_create_subtasks, :subtask_trackers, :create_relation,
+        :update_relation, :destroy_relation, :save_baseline
+      ]
+    }
+    permission :manage_canvas_gantt_baseline, { canvas_gantts: [:save_baseline] }
   end
 
   menu :project_menu, :canvas_gantt, { controller: 'canvas_gantts', action: 'index' }, caption: 'Canvas Gantt', after: :gantt, param: :project_id

--- a/spec/controllers/canvas_gantts_controller_spec.rb
+++ b/spec/controllers/canvas_gantts_controller_spec.rb
@@ -106,6 +106,18 @@ RSpec.describe CanvasGanttsController, type: :controller do
       expect(JSON.parse(response.body)).to eq('error' => 'Permission denied')
     end
 
+    it 'requires view permission before a direct mutation API request is processed' do
+      allow(controller).to receive(:set_permissions) do
+        controller.instance_variable_set(:@permissions, { editable: true, viewable: false, baseline_editable: true })
+      end
+      expect(Issue).not_to receive(:visible)
+
+      patch :update, params: { project_id: 'demo', id: '10', task: { subject: 'Denied' } }, format: :json
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)).to eq('error' => 'Permission denied')
+    end
+
     it 'returns data payload with expected top-level keys' do
       payload_builder = instance_double(RedmineCanvasGantt::DataPayloadBuilder)
       baseline_repository = instance_double(RedmineCanvasGantt::BaselineRepository)
@@ -393,7 +405,7 @@ RSpec.describe CanvasGanttsController, type: :controller do
       allow(controller).to receive(:descendant_project_ids).and_return([1])
       allow(User).to receive(:current).and_return(current_user)
       allow(current_user).to receive(:allowed_to?).and_return(false)
-      allow(current_user).to receive(:allowed_to?).with(:edit_canvas_gantt, project).and_return(true)
+      allow(current_user).to receive(:allowed_to?).with(:manage_canvas_gantt_baseline, project).and_return(true)
       allow(controller).to receive(:set_permissions) do
         controller.instance_variable_set(:@permissions, { editable: true, viewable: true, baseline_editable: true })
       end
@@ -483,7 +495,7 @@ RSpec.describe CanvasGanttsController, type: :controller do
     end
 
     it 'returns forbidden when edit permission is missing' do
-      allow(current_user).to receive(:allowed_to?).with(:edit_canvas_gantt, project).and_return(false)
+      allow(current_user).to receive(:allowed_to?).with(:manage_canvas_gantt_baseline, project).and_return(false)
 
       post :save_baseline, params: { project_id: 'demo' }, format: :json
 
@@ -780,6 +792,27 @@ RSpec.describe CanvasGanttsController, type: :controller do
 
       expect(response).to have_http_status(:ok)
       expect(JSON.parse(response.body)['status']).to eq('ok')
+    end
+  end
+
+  describe '#issue_editable?' do
+    let(:current_user) { instance_double(User) }
+    let(:canvas_project) { instance_double(Project, id: 1, name: 'Parent') }
+    let(:child_project) { instance_double(Project, id: 2, name: 'Child') }
+    let(:child_issue) { instance_double(Issue, project: child_project, editable?: true) }
+
+    before do
+      allow(User).to receive(:current).and_return(current_user)
+      allow(current_user).to receive(:allowed_to?).and_return(false)
+    end
+
+    it 'uses the target child issue project rather than the canvas project' do
+      allow(current_user).to receive(:allowed_to?).with(:edit_issues, child_project).and_return(true)
+      allow(current_user).to receive(:allowed_to?).with(:edit_issues, canvas_project).and_return(false)
+
+      expect(controller.send(:issue_editable?, child_issue)).to be(true)
+      expect(current_user).to have_received(:allowed_to?).with(:edit_issues, child_project)
+      expect(current_user).not_to have_received(:allowed_to?).with(:edit_issues, canvas_project)
     end
   end
 


### PR DESCRIPTION
## Summary

* Refactored permission checks by replacing `edit_canvas_gantt` with `manage_canvas_gantt_baseline` to provide precise access control for Gantt chart baseline operations.

## Background

* The previous `edit_canvas_gantt` permission key was overly broad, preventing granular control over baseline management separately from general Gantt chart editing.

## Changes

* Replaced the `edit_canvas_gantt` permission identifier with `manage_canvas_gantt_baseline`.
* Updated permission validation logic and guards across relevant UI components and backend endpoints.

## Testing

* [x] npm run lint
* [x] npm run test -- --run
* [x] npm run build

## Risks

* Users or roles relying on the legacy `edit_canvas_gantt` permission may lose access to baseline management features until permissions/roles are re-assigned in the database.

## Related Issues

* Fixes #